### PR TITLE
Increase minimum Rails version to 7.1.1

### DIFF
--- a/nextgen.gemspec
+++ b/nextgen.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", "~> 7.1.0"
+  spec.add_dependency "railties", "~> 7.1.1"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "tty-prompt", "~> 0.23.1"
   spec.add_dependency "tty-screen", "~> 0.8.1"


### PR DESCRIPTION
Rails 7.1.1 brings an important bug fixes regarding app generation:

- Dockerfile now uses correct Ruby version
- CI works even if Action Text, etc. migrations haven't been run yet