### PR TITLE
Enable webmock alongside installing the gem

### DIFF
--- a/config/generators.yml
+++ b/config/generators.yml
@@ -131,7 +131,7 @@ tomo:
 
 vcr:
   prompt: "VCR"
-  description: "Install and configure the vcr gem"
+  description: "Install and configure vcr and webmock gems"
   requires: test_framework
 
 rubocop:

--- a/lib/nextgen/generators/vcr.rb
+++ b/lib/nextgen/generators/vcr.rb
@@ -1,2 +1,3 @@
 install_gems "vcr", "webmock", group: :test
+copy_test_support_file "webmock.rb"
 template "test/support/vcr.rb.tt", rspec? ? "spec/support/vcr.rb" : "test/support/vcr.rb"

--- a/template/spec/support/webmock.rb
+++ b/template/spec/support/webmock.rb
@@ -1,0 +1,1 @@
+require "webmock/rspec"

--- a/template/test/support/webmock.rb
+++ b/template/test/support/webmock.rb
@@ -1,0 +1,1 @@
+require "webmock/minitest"

--- a/test/nextgen/generators/vcr_test.rb
+++ b/test/nextgen/generators/vcr_test.rb
@@ -19,15 +19,24 @@ class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase
     end
   end
 
-  test "adds a test/support/vcr.rb file" do
+  test "when minitest is present, adds vcr and webmock test support files" do
+    Dir.chdir(destination_root) do
+      FileUtils.mkdir_p("test")
+      FileUtils.touch("test/test_helper.rb")
+    end
+
     apply_generator
 
     assert_file "test/support/vcr.rb" do |support|
       refute_match(/rspec/, support)
     end
+
+    assert_file "test/support/webmock.rb" do |support|
+      assert_match('require "webmock/minitest"', support)
+    end
   end
 
-  test "when rspec is present, adds a spec/support/vcr.rb file" do
+  test "when rspec is present, adds vcr and webmock spec support files" do
     Dir.chdir(destination_root) do
       FileUtils.mkdir_p("spec/support")
       FileUtils.touch("spec/spec_helper.rb")
@@ -37,6 +46,10 @@ class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase
 
     assert_file "spec/support/vcr.rb" do |support|
       assert_match(/rspec/, support)
+    end
+
+    assert_file "spec/support/webmock.rb" do |support|
+      assert_match('require "webmock/rspec"', support)
     end
   end
 end


### PR DESCRIPTION
Before, webmock was installed purely as an adapter for vcr. But it is often useful to have the webmock DSL available to use directly. This commit adds the necessary `require` statement to enable the webmock DSL within minitest and rspec.