### PR TITLE
Improve Capybara config; extract to separate support file

### DIFF
--- a/lib/nextgen/actions.rb
+++ b/lib/nextgen/actions.rb
@@ -54,16 +54,18 @@ module Nextgen
     end
 
     def copy_test_support_file(file)
+      copy_action = file.end_with?(".tt") ? method(:template) : method(:copy_file)
+
       if minitest?
         create_test_support_directory
-        copy_file "test/support/#{file}"
+        copy_action.call "test/support/#{file}"
       elsif rspec?
         empty_directory "spec/support"
         spec_file_path = "spec/support/#{file}"
         if Nextgen.template_path.join(spec_file_path).exist?
-          copy_file spec_file_path
+          copy_action.call spec_file_path
         else
-          copy_file "test/support/#{file}", spec_file_path
+          copy_action.call "test/support/#{file}", spec_file_path.sub(/\.tt$/, "")
         end
       end
     end

--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -27,6 +27,7 @@ RUBY
 
 if File.exist?("test/application_system_test_case.rb")
   say_git "Configure system tests"
+  copy_test_support_file "capybara.rb.tt"
   copy_file "test/application_system_test_case.rb", force: true
 end
 

--- a/lib/nextgen/generators/rspec_system_testing.rb
+++ b/lib/nextgen/generators/rspec_system_testing.rb
@@ -1,4 +1,5 @@
 install_gems "capybara", "selenium-webdriver", group: :test
+copy_test_support_file "capybara.rb.tt"
 copy_test_support_file "system.rb"
 
 copy_file "lib/templates/rspec/system/system_spec.rb"

--- a/lib/nextgen/generators/vcr.rb
+++ b/lib/nextgen/generators/vcr.rb
@@ -1,3 +1,3 @@
 install_gems "vcr", "webmock", group: :test
+copy_test_support_file "vcr.rb.tt"
 copy_test_support_file "webmock.rb"
-template "test/support/vcr.rb.tt", rspec? ? "spec/support/vcr.rb" : "test/support/vcr.rb"

--- a/template/spec/support/system.rb
+++ b/template/spec/support/system.rb
@@ -1,9 +1,3 @@
-require "capybara/rails"
-require "capybara/rspec"
-
-Capybara.default_max_wait_time = 2
-Capybara.disable_animation = true
-
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium,

--- a/template/test/application_system_test_case.rb
+++ b/template/test/application_system_test_case.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "capybara/rails"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium,
@@ -9,10 +8,4 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       options.add_argument("--disable-dev-shm-usage")
       options.add_argument("--no-sandbox")
     end
-
-  setup do
-    Capybara.default_max_wait_time = 2
-    Capybara.disable_animation = true
-    Capybara.server = :puma, {Silent: true}
-  end
 end

--- a/template/test/support/capybara.rb.tt
+++ b/template/test/support/capybara.rb.tt
@@ -1,0 +1,12 @@
+require "capybara/rails"
+<% if rspec? -%>
+require "capybara/rspec"
+<% end -%>
+
+Capybara.configure do |config|
+  config.default_max_wait_time = 2
+  config.disable_animation = true
+  config.enable_aria_label = true
+  config.server = :puma, {Silent: true}
+  config.test_id = "data-testid"
+end

--- a/test/nextgen/generators/rspec_system_testing_test.rb
+++ b/test/nextgen/generators/rspec_system_testing_test.rb
@@ -1,0 +1,31 @@
+require_relative "test_case"
+
+class Nextgen::Generators::RspecSystemTestingTest < Nextgen::Generators::TestCase
+  destination File.join(Dir.tmpdir, "test_#{SecureRandom.hex(8)}")
+  setup :prepare_destination
+
+  setup do
+    empty_destination_gemfile
+    touch_destination_paths(%w[config/application.rb spec/spec_helper.rb])
+  end
+
+  test "installs capybara and selenium gems" do
+    apply_generator
+
+    assert_file "Gemfile", /#{Regexp.quote(<<~GEMFILE)}/
+      group :test do
+        gem "selenium-webdriver"
+        gem "capybara"
+      end
+    GEMFILE
+  end
+
+  test "configures capybara and system specs" do
+    apply_generator
+
+    assert_file "spec/support/capybara.rb", %r{require "capybara/rspec"\n}
+    assert_file "spec/support/capybara.rb", /^Capybara\.configure/
+
+    assert_file "spec/support/system.rb", /driven_by :selenium/
+  end
+end

--- a/test/nextgen/generators/test_case.rb
+++ b/test/nextgen/generators/test_case.rb
@@ -2,11 +2,24 @@ require "test_helper"
 require "securerandom"
 require "tmpdir"
 require "rails/generators/test_case"
-
 require "rails/generators/rails/app/app_generator"
 
 class Nextgen::Generators::TestCase < Rails::Generators::TestCase
   private
+
+  def empty_destination_gemfile
+    Pathname.new(destination_root).join("Gemfile").write(<<~GEMFILE)
+      source "https://rubygems.org"
+    GEMFILE
+  end
+
+  def touch_destination_paths(*paths)
+    paths.flatten.each do |path|
+      dest = Pathname.new(destination_root).join(path)
+      FileUtils.mkdir_p dest.dirname
+      FileUtils.touch dest
+    end
+  end
 
   def apply_generator(name = self.class.name.underscore[/(\w+)_test$/, 1])
     generators = Nextgen::Generators.new

--- a/test/nextgen/generators/vcr_test.rb
+++ b/test/nextgen/generators/vcr_test.rb
@@ -3,20 +3,17 @@ require_relative "test_case"
 class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase
   destination File.join(Dir.tmpdir, "test_#{SecureRandom.hex(8)}")
   setup :prepare_destination
-
-  setup do
-    Pathname.new(destination_root).join("Gemfile").write(<<~GEMFILE)
-      source "https://rubygems.org"
-    GEMFILE
-  end
+  setup :empty_destination_gemfile
 
   test "installs vcr and webmock gems" do
     apply_generator
 
-    assert_file "Gemfile" do |gemfile|
-      assert_match(/gem "vcr"/, gemfile)
-      assert_match(/gem "webmock"/, gemfile)
-    end
+    assert_file "Gemfile", /#{Regexp.quote(<<~GEMFILE)}/
+      group :test do
+        gem "webmock"
+        gem "vcr"
+      end
+    GEMFILE
   end
 
   test "when minitest is present, adds vcr and webmock test support files" do


### PR DESCRIPTION
- Configure Capybara's `enable_aria_label` and `test_id`
- Enhance `copy_test_support_file` to support `.tt` templates
- Refactor generator tests with helper methods like `empty_destination_gemfile`