### PR TITLE
Lock stylelint at ^15 for now

### DIFF
--- a/lib/nextgen/generators/stylelint.rb
+++ b/lib/nextgen/generators/stylelint.rb
@@ -1,7 +1,7 @@
 say_git "Install stylelint"
 add_yarn_packages(
-  "stylelint",
-  "stylelint-config-standard",
+  "stylelint@^15",
+  "stylelint-config-standard@^34",
   "stylelint-declaration-strict-value",
   "stylelint-prettier",
   "prettier",


### PR DESCRIPTION
The `stylelint-declaration-strict-value` plugin does not yet work with stylelint 16. Lock our dependency at stylelint ^15 for the time being as a workaround.