### PR TITLE
Make RuboCop aware of Rails `concerning` and `delegate` methods

### DIFF
--- a/template/.rubocop.yml.tt
+++ b/template/.rubocop.yml.tt
@@ -77,6 +77,12 @@ Lint/AmbiguousBlockAssociation:
 Lint/DuplicateBranch:
   Enabled: false
 
+Lint/UselessAccessModifier:
+  ContextCreatingMethods:
+    - concerning
+  MethodCreatingMethods:
+    - delegate
+
 Metrics/AbcSize:
   Enabled: false
 


### PR DESCRIPTION
In its default configuration, RuboCop's `Lint/UselessAccessModifier` rule can get confused by the `concerning` and `delegate` constructs in Rails.

Take this code for example,

```ruby
class User < ApplicationRecord
  concerning :Authentication do
    has_secure_password
    before_save :some_callback_method

    private

    def some_callback_method
      # ...
    end
  end

  private

  def another_private_method
    # ...
  end
end
```

RuboCop sees two `private` modifiers and considers this a violation, even though they take place in two different scopes.

This PR fixes this by configuring `Lint/UselessAccessModifier` to understand Rails-specific syntax, as recommended in the RuboCop docs: https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessaccessmodifier