### PR TITLE
Pin all stylelint packages to avoid incompatibilities

### DIFF
--- a/lib/nextgen/generators/stylelint.rb
+++ b/lib/nextgen/generators/stylelint.rb
@@ -2,8 +2,8 @@ say_git "Install stylelint"
 add_yarn_packages(
   "stylelint@^15",
   "stylelint-config-standard@^34",
-  "stylelint-declaration-strict-value",
-  "stylelint-prettier",
+  "stylelint-declaration-strict-value@^1",
+  "stylelint-prettier@^4",
   "prettier",
   "npm-run-all",
   dev: true


### PR DESCRIPTION
It seems that Stylelint 16 has caused a lot of breakage in Stylelint packages. Plugins updated for v16 don't work with v15, and those that haven't been updated yet won't work with v16. To keep things working, it is necessary to explicitly pin all of our Stylelint dependencies at specific versions.