### PR TITLE
Fix missing Stylelint config in generated .overcommit.yml

### DIFF
--- a/template/.overcommit.yml.tt
+++ b/template/.overcommit.yml.tt
@@ -63,7 +63,7 @@ PreCommit:
     on_warn: fail
 <% end -%>
 
-<% if File.exist?(".stylelintrc.cjs") -%>
+<% if File.exist?(".stylelintrc.js") -%>
   Stylelint:
     enabled: true
     required_executable: npx


### PR DESCRIPTION
The `stylelintrc` file was renamed in #33, which inadvertently caused Stylelint to get skipped in the generated Overcommit config. This commit fixes the issue.