### PR TITLE
Remove recommendation for Capybara `disable_animation`

### DIFF
--- a/template/test/support/capybara.rb.tt
+++ b/template/test/support/capybara.rb.tt
@@ -5,7 +5,6 @@ require "capybara/rspec"
 
 Capybara.configure do |config|
   config.default_max_wait_time = 2
-  config.disable_animation = true
   config.enable_aria_label = true
   config.server = :puma, {Silent: true}
   config.test_id = "data-testid"


### PR DESCRIPTION
Capybara's `disable_animation` option inserts a middleware that can conflict with other middleware, like `Rack::Deflater`. If removing animation is important for speeding up system tests, a more direct way to do it is to conditionally add CSS/JS to the application layout, rather rely on a middleware that could have unexpected side effects.

Given the potential complications, I am removing `disable_animation` from the default Capybara config file that nextgen generates.