### PR TITLE
Recommend dotenv >= 3.0 for newly generated apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Nextgen can install and configure your choice of these recommended gems:
 - [brakeman](https://github.com/presidentbeef/brakeman)
 - [bundler-audit](https://github.com/rubysec/bundler-audit)
 - [capybara-lockstep](https://github.com/makandra/capybara-lockstep)
-- [dotenv-rails](https://github.com/bkeepers/dotenv)
+- [dotenv](https://github.com/bkeepers/dotenv)
 - [erb_lint](https://github.com/Shopify/erb-lint)
 - [factory_bot_rails](https://github.com/thoughtbot/factory_bot_rails)
 - [good_migrations](https://github.com/testdouble/good-migrations)

--- a/config/generators.yml
+++ b/config/generators.yml
@@ -51,8 +51,8 @@ capybara_lockstep:
   requires: system_testing
 
 dotenv:
-  prompt: "dotenv-rails"
-  description: "Install dotenv-rails gem and add .env.sample"
+  prompt: "dotenv"
+  description: "Install dotenv gem and add .env.sample"
 
 erb_lint:
   prompt: "ERB Lint"

--- a/lib/nextgen/generators/dotenv.rb
+++ b/lib/nextgen/generators/dotenv.rb
@@ -1,3 +1,3 @@
-install_gem "dotenv-rails", group: %i[development test]
+install_gem "dotenv", version: ">= 3.0", group: %i[development test]
 copy_file ".env.sample"
 gitignore "/.env*", "!/.env.sample"


### PR DESCRIPTION
Starting with dotenv 3.0, the `dotenv-rails` gem has been soft-deprecated. The `dotenv` gem itself now has Rails integration built-in.

Update nextgen to use this simpler dependency.