### PR TITLE
Mark vcr cassettes as generated files via .gitattributes

### DIFF
--- a/lib/nextgen/generators/vcr.rb
+++ b/lib/nextgen/generators/vcr.rb
@@ -1,3 +1,8 @@
 install_gems "vcr", "webmock", group: :test
 copy_test_support_file "vcr.rb.tt"
 copy_test_support_file "webmock.rb"
+append_to_file ".gitattributes", <<~GITATTRS if File.exist?(".gitattributes")
+
+  # Mark VCR cassettes as having been generated.
+  #{rspec? ? "spec" : "test"}/cassettes/** linguist-generated
+GITATTRS

--- a/test/nextgen/generators/vcr_test.rb
+++ b/test/nextgen/generators/vcr_test.rb
@@ -20,9 +20,14 @@ class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase
     Dir.chdir(destination_root) do
       FileUtils.mkdir_p("test")
       FileUtils.touch("test/test_helper.rb")
+      FileUtils.touch(".gitattributes")
     end
 
     apply_generator
+
+    assert_file ".gitattributes" do |attrs|
+      assert_match("test/cassettes/** linguist-generated", attrs)
+    end
 
     assert_file "test/support/vcr.rb" do |support|
       refute_match(/rspec/, support)
@@ -37,9 +42,14 @@ class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase
     Dir.chdir(destination_root) do
       FileUtils.mkdir_p("spec/support")
       FileUtils.touch("spec/spec_helper.rb")
+      FileUtils.touch(".gitattributes")
     end
 
     apply_generator
+
+    assert_file ".gitattributes" do |attrs|
+      assert_match("spec/cassettes/** linguist-generated", attrs)
+    end
 
     assert_file "spec/support/vcr.rb" do |support|
       assert_match(/rspec/, support)


### PR DESCRIPTION
Mark vcr cassettes as having been generated, so that GitHub hides them in PR diffs by default. This is similar to how `db/schema.rb` is marked as being generated by the default `rails new` template.