### PR TITLE
Adjust glob expression for vcr cassette git attributes

### DIFF
--- a/lib/nextgen/generators/vcr.rb
+++ b/lib/nextgen/generators/vcr.rb
@@ -4,5 +4,5 @@ copy_test_support_file "webmock.rb"
 append_to_file ".gitattributes", <<~GITATTRS if File.exist?(".gitattributes")
 
   # Mark VCR cassettes as having been generated.
-  #{rspec? ? "spec" : "test"}/cassettes/** linguist-generated
+  #{rspec? ? "spec" : "test"}/cassettes/* linguist-generated
 GITATTRS

--- a/test/nextgen/generators/vcr_test.rb
+++ b/test/nextgen/generators/vcr_test.rb
@@ -26,7 +26,7 @@ class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase
     apply_generator
 
     assert_file ".gitattributes" do |attrs|
-      assert_match("test/cassettes/** linguist-generated", attrs)
+      assert_match("test/cassettes/* linguist-generated", attrs)
     end
 
     assert_file "test/support/vcr.rb" do |support|
@@ -48,7 +48,7 @@ class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase
     apply_generator
 
     assert_file ".gitattributes" do |attrs|
-      assert_match("spec/cassettes/** linguist-generated", attrs)
+      assert_match("spec/cassettes/* linguist-generated", attrs)
     end
 
     assert_file "spec/support/vcr.rb" do |support|


### PR DESCRIPTION
The correct pattern seems to be a single `*` wildcard, not `**`, based on how GitHub PRs are rendered.