### PR TITLE
Fix capybara screenshot location to work with CI

### DIFF
--- a/template/test/support/capybara.rb.tt
+++ b/template/test/support/capybara.rb.tt
@@ -5,6 +5,7 @@ require "capybara/rspec"
 
 Capybara.configure do |config|
   config.default_max_wait_time = 2
+  config.save_path = "tmp/screenshots"
   config.enable_aria_label = true
   config.server = :puma, {Silent: true}
   config.test_id = "data-testid"


### PR DESCRIPTION
The generated GitHub Actions CI job expects screenshots in `tmp/screenshots`, but Capybara was placing them in `tmp/capybara`. Set the configuration explicitly to fix this.
