### PR TITLE
Skip building vite assets in tests if possible

### DIFF
--- a/lib/nextgen/generators/vite.rb
+++ b/lib/nextgen/generators/vite.rb
@@ -46,9 +46,13 @@ say_git "Install autoprefixer"
 add_yarn_packages "postcss@^8.4.24", "autoprefixer@^10.4.14"
 copy_file "postcss.config.cjs"
 
-say_git "Disable autoBuild in test environment"
-gsub_file "config/vite.json", /("test": \{.+?"autoBuild":\s*)true/m, '\1false'
-copy_test_support_file "vite.rb"
+# TODO: rspec support
+if File.exist?("test/application_system_test_case.rb")
+  say_git "Disable autoBuild in test environment"
+  gsub_file "config/vite.json", /("test": \{.+?"autoBuild":\s*)true/m, '\1false'
+  copy_file "test/vite_helper.rb"
+  inject_into_file "test/application_system_test_case.rb", "\nrequire \"vite_helper\"", after: /require "test_helper"$/
+end
 
 say_git "Install modern-normalize and base stylesheets"
 add_yarn_package "modern-normalize@^2.0.0"
@@ -84,7 +88,7 @@ end
 copy_file "app/helpers/inline_svg_helper.rb"
 copy_file "app/frontend/images/example.svg"
 # TODO: rspec support
-copy_file "test/helpers/inline_svg_helper_test.rb" if minitest?
+copy_file "test/helpers/inline_svg_helper_test.rb" if File.exist?("test/vite_helper.rb")
 
 say_git "Add a `yarn start` script"
 start = "concurrently -i -k --kill-others-on-fail -p none 'RUBY_DEBUG_OPEN=true bin/rails s' 'bin/vite dev'"

--- a/template/test/helpers/inline_svg_helper_test.rb
+++ b/template/test/helpers/inline_svg_helper_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "vite_helper"
 
 class InlineSvgHelperTest < ActionView::TestCase
   test "inline_svg_tag returns contents of svg file as html_safe string" do

--- a/template/test/support/vite.rb
+++ b/template/test/support/vite.rb
@@ -1,5 +1,7 @@
-return if ViteRuby.config.auto_build
-
-# Compile assets once at the start of testing
-millis = Benchmark.ms { ViteRuby.commands.build }
-puts format("Built Vite assets (%.1fms)", millis)
+# Compile assets once at the start of system testing
+ActiveSupport.on_load(:action_dispatch_system_test_case) do
+  unless ViteRuby.config.auto_build
+    millis = Benchmark.ms { ViteRuby.commands.build }
+    puts format("Built Vite assets (%.1fms)", millis)
+  end
+end

--- a/template/test/support/vite.rb
+++ b/template/test/support/vite.rb
@@ -1,7 +1,0 @@
-# Compile assets once at the start of system testing
-ActiveSupport.on_load(:action_dispatch_system_test_case) do
-  unless ViteRuby.config.auto_build
-    millis = Benchmark.ms { ViteRuby.commands.build }
-    puts format("Built Vite assets (%.1fms)", millis)
-  end
-end

--- a/template/test/vite_helper.rb
+++ b/template/test/vite_helper.rb
@@ -1,0 +1,5 @@
+return if ViteRuby.config.auto_build
+
+# Compile assets once at the start of testing
+millis = Benchmark.ms { ViteRuby.commands.build }
+puts format("Built Vite assets (%.1fms)", millis)


### PR DESCRIPTION
Previously, the presence of `vite.rb` in `test/support/` meant that Vite assets would be eagerly built whenever any type of test was run. When running a model test, for example, this would lead to unnecessarily slow test startup time.

What we want is to compile Vite assets before system tests, and before helper tests that specifically expect compiled assets.

Implement this by moving the Vite compilation logic to `test/vite_helper.rb`. Tests can now explicitly `require "vite_helper"` if they require compiled assets.

Add `require "vite_helper"` to `application_system_test_case.rb` so that system tests always have compiled assets.