### PR TITLE
Automatically configure default time zone in generated app

### DIFF
--- a/lib/nextgen/actions.rb
+++ b/lib/nextgen/actions.rb
@@ -153,5 +153,11 @@ module Nextgen
 
       raise Thor::Error, message
     end
+
+    def read_system_time_zone_name
+      return unless File.symlink?("/etc/localtime")
+
+      File.readlink("/etc/localtime")[%r{zoneinfo/(.+)$}, 1]
+    end
   end
 end

--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -59,3 +59,9 @@ if File.exist?("config/database.yml")
   say_git "Create initial schema.rb"
   rails_command "db:prepare"
 end
+
+if (time_zone = read_system_time_zone_name)
+  say_git "Set default time zone: #{time_zone}"
+  uncomment_lines "config/application.rb", /config\.time_zone/
+  gsub_file "config/application.rb", /(config\.time_zone = ).*$/, "\\1#{time_zone.inspect}"
+end


### PR DESCRIPTION
On macOS and Linux, determine the local time zone by inspecting the `/etc/localtime` symlink, and assign it to `config.time_zone` in the generated Rails `application.rb`.