### PR TITLE
Add more color and improve interactivity of menu options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /Gemfile.lock
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 /spec/reports/
 /tmp/
 /Gemfile.lock
-/.idea/


### PR DESCRIPTION
This PR is a repackaging of a portion of the changes originally proposed by @zhandao in #47.

Enhancements:

- Highlight important information in cyan: app name and generated app path.
- Turn on the `:cycle` option for select menus, so that cursor wraps around when using arrow keys to navigate.

Refactor:

- Use "end-less" method syntax to define `cyan`, `green`, and `yellow` color helpers.