### PR TITLE
Drop support for Ruby 3.0 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "head"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   Exclude:
     - "examples/**/*"
     - "tmp/**/*"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Nextgen is an **interactive** and flexible alternative to `rails new` that inclu
 
 Nextgen generates apps using **Rails 7.1**.
 
-- **Ruby 3.0+** is required
+- **Ruby 3.1+** is required
 - **Rubygems 3.4.8+** is required (run `gem update --system` to get it)
 - **Node 18.12+ and Yarn** are required if you choose Vite or other Node-based options
 - Additional tools may be required depending on the options you select (e.g. PostgreSQL)

--- a/Rakefile
+++ b/Rakefile
@@ -67,6 +67,7 @@ namespace :bump do
     replace_in_file "nextgen.gemspec", /ruby_version = .*">= (.*)"/ => RubyVersions.lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => RubyVersions.lowest
     replace_in_file ".github/workflows/ci.yml", /ruby: (\[.+\])/ => RubyVersions.all.inspect
+    replace_in_file "README.md", /Ruby (\d+\.\d+)\+/ => RubyVersions.lowest
   end
 
   task :year do

--- a/lib/nextgen/actions.rb
+++ b/lib/nextgen/actions.rb
@@ -22,7 +22,7 @@ module Nextgen
         result, status = Open3.capture2e(env, cmd)
         success = status.success?
       else
-        result = success = run(cmd, env: env, verbose: verbose)
+        result = success = run(cmd, env:, verbose:)
       end
 
       return result if success

--- a/lib/nextgen/actions/bundler.rb
+++ b/lib/nextgen/actions/bundler.rb
@@ -13,7 +13,7 @@ module Nextgen
           false
         else
           say_status :gemfile, [name, version].compact.join(", ")
-          gemfile.add(name, version: version, group: group, require: require)
+          gemfile.add(name, version:, group:, require:)
           true
         end
       end
@@ -44,7 +44,7 @@ module Nextgen
 
       Bundler.with_original_env do
         say_status :bundle, cmd, :green if verbose
-        run! full_command, env: {"BUNDLE_IGNORE_MESSAGES" => "1"}, verbose: false, capture: capture
+        run! full_command, env: {"BUNDLE_IGNORE_MESSAGES" => "1"}, verbose: false, capture:
       end
     end
 

--- a/lib/nextgen/actions/yarn.rb
+++ b/lib/nextgen/actions/yarn.rb
@@ -7,7 +7,7 @@ module Nextgen
     alias add_yarn_package add_yarn_packages
 
     def remove_yarn_packages(*packages, capture: false)
-      yarn_command "remove #{packages.map(&:shellescape).join(" ")}", capture: capture
+      yarn_command "remove #{packages.map(&:shellescape).join(" ")}", capture:
     end
     alias remove_yarn_package remove_yarn_packages
 

--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -242,7 +242,7 @@ module Nextgen
     end
 
     def ask_optional_enhancements
-      @generators = Generators.compatible_with(rails_opts: rails_opts)
+      @generators = Generators.compatible_with(rails_opts:)
 
       answers = prompt.multi_select(
         "Which optional enhancements would you like to add?",

--- a/lib/nextgen/generators.rb
+++ b/lib/nextgen/generators.rb
@@ -40,7 +40,7 @@ module Nextgen
       name = name.to_sym
       raise ArgumentError, "Generator #{name.inspect} was already added" if generators.key?(name)
 
-      generators[name] = {node: node, prompt: prompt, description: description}
+      generators[name] = {node:, prompt:, description:}
       activate(name) unless prompt
     end
 

--- a/lib/nextgen/generators/vite.rb
+++ b/lib/nextgen/generators/vite.rb
@@ -92,7 +92,7 @@ copy_file "test/helpers/inline_svg_helper_test.rb" if File.exist?("test/vite_hel
 
 say_git "Add a `yarn start` script"
 start = "concurrently -i -k --kill-others-on-fail -p none 'RUBY_DEBUG_OPEN=true bin/rails s' 'bin/vite dev'"
-add_package_json_script start: start
+add_package_json_script(start:)
 add_yarn_package "concurrently", dev: true
 gsub_file "README.md", %r{bin/rails s(erver)?}, "yarn start"
 gsub_file "bin/setup", %r{bin/rails s(erver)?}, "yarn start"

--- a/lib/nextgen/rails.rb
+++ b/lib/nextgen/rails.rb
@@ -29,10 +29,10 @@ module Nextgen
         Thor::Base.shell.new.say_status(...)
       end
 
-      def with_original_bundler_env(&block)
+      def with_original_bundler_env(&)
         return yield unless defined?(Bundler)
 
-        Bundler.with_original_env(&block)
+        Bundler.with_original_env(&)
       end
     end
   end

--- a/lib/nextgen/thor_extensions.rb
+++ b/lib/nextgen/thor_extensions.rb
@@ -23,7 +23,7 @@ module Nextgen
 
       if given_args.first == "help"
         retry_with_args = ["help"] if given_args.length > 1
-      elsif (e.unknown & %w[-h --help]).any?
+      elsif e.unknown.intersect?(%w[-h --help])
         retry_with_args = ["help", (given_args - e.unknown).first]
       end
       raise unless retry_with_args.any?

--- a/lib/nextgen/tidy_gemfile.rb
+++ b/lib/nextgen/tidy_gemfile.rb
@@ -27,7 +27,7 @@ module Nextgen
     def add(gem, version: nil, group: nil, require: nil)
       return false if include?(gem)
 
-      gem_line = build_gem_line(gem, version: version, require: require, indent: group ? "  " : "")
+      gem_line = build_gem_line(gem, version:, require:, indent: group ? "  " : "")
 
       if group
         group_line = create_group_if_needed(group)

--- a/nextgen.gemspec
+++ b/nextgen.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
                      "that includes opt-in support for modern frontend development with Vite."
   spec.homepage = "https://github.com/mattbrictson/nextgen"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/nextgen/issues",

--- a/template/bin/setup
+++ b/template/bin/setup
@@ -27,7 +27,7 @@ def run(command, echo: true, silent: false, exception: true)
   say_status(:run, command, :blue) if echo
   with_original_bundler_env do
     options = silent ? {out: File::NULL, err: File::NULL} : {}
-    system(command, exception: exception, **options)
+    system(command, exception:, **options)
   end
 end
 

--- a/template/bin/setup
+++ b/template/bin/setup
@@ -59,10 +59,10 @@ def git_safe_needed?
   ENV["PATH"].include?(".git/safe/../../bin") && !Dir.exist?(".git/safe")
 end
 
-def with_original_bundler_env(&block)
+def with_original_bundler_env(&)
   return yield unless defined?(Bundler)
 
-  Bundler.with_original_env(&block)
+  Bundler.with_original_env(&)
 end
 
 def env(env_file, from:)

--- a/test/e2e/nextgen_e2e_test.rb
+++ b/test/e2e/nextgen_e2e_test.rb
@@ -46,10 +46,10 @@ class NextgenE2ETest < Minitest::Test
     assert(status.success?, "Expected #{command.inspect} to run without error")
   end
 
-  def in_temp_dir(&block)
+  def in_temp_dir(&)
     token = SecureRandom.hex(8)
     dir = File.join(Dir.tmpdir, "nextgen_test_#{token}")
     FileUtils.mkdir_p(dir)
-    Dir.chdir(dir, &block)
+    Dir.chdir(dir, &)
   end
 end

--- a/test/e2e/nextgen_e2e_test.rb
+++ b/test/e2e/nextgen_e2e_test.rb
@@ -20,7 +20,7 @@ class NextgenE2ETest < Minitest::Test
 
   def assert_bundle_exec_nextgen_create(stdin_data:)
     in_temp_dir do
-      bundle_exec! "nextgen create myapp", stdin_data: stdin_data
+      bundle_exec!("nextgen create myapp", stdin_data:)
       Bundler.with_original_env do
         Dir.chdir("myapp") do
           bundle_exec!("bin/setup")

--- a/test/integration/generators/test_case.rb
+++ b/test/integration/generators/test_case.rb
@@ -44,7 +44,7 @@ class Nextgen::Generators::TestCase < Rails::Generators::TestCase
     generator = Rails::Generators::AppGenerator.new(
       [destination_root],
       {template: template.to_s},
-      {destination_root: destination_root}
+      {destination_root:}
     )
     generator.set_default_accessors!
     generator.apply_rails_template

--- a/test/nextgen/rails_options_test.rb
+++ b/test/nextgen/rails_options_test.rb
@@ -214,8 +214,8 @@ class Nextgen::RailsOptionsTest < Minitest::Test
 
   private
 
-  def assert_prohibited(&block)
-    error = assert_raises(ArgumentError, &block)
+  def assert_prohibited(&)
+    error = assert_raises(ArgumentError, &)
     assert_match(/Can't specify/i, error.message)
   end
 end


### PR DESCRIPTION
- Adopt Ruby 3.1+ implicit hash syntax
- Adopt Ruby 3.1+ anonymous block arg syntax
- Adopt Ruby 3.1+ `Array#intersect?`