### PR TITLE
Add frozen_string_literal comments and enable RuboCop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -159,9 +159,6 @@ Style/FetchEnvVar:
 Style/FormatStringToken:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/GuardClause:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "nextgen"

--- a/exe/nextgen
+++ b/exe/nextgen
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "nextgen"
 

--- a/lib/nextgen.rb
+++ b/lib/nextgen.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 require "zeitwerk"
 

--- a/lib/nextgen/actions.rb
+++ b/lib/nextgen/actions.rb
@@ -84,9 +84,9 @@ module Nextgen
 
     def document_deploy_var(var_name, desc = nil, required: false, default: nil)
       insertion = "`#{var_name}`"
-      insertion << " **REQUIRED**" if required
-      insertion << " - #{desc}" if desc.present?
-      insertion << " (default: #{default})" unless default.nil?
+      insertion += " **REQUIRED**" if required
+      insertion += " - #{desc}" if desc.present?
+      insertion += " (default: #{default})" unless default.nil?
 
       copy_file "DEPLOYMENT.md" unless File.exist?("DEPLOYMENT.md")
       inject_into_file "DEPLOYMENT.md", "#{insertion}\n- ", after: /^## Environment variables.*?^- /m

--- a/lib/nextgen/actions.rb
+++ b/lib/nextgen/actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nextgen
   module Actions
     include Bundler

--- a/lib/nextgen/actions/bundler.rb
+++ b/lib/nextgen/actions/bundler.rb
@@ -23,7 +23,7 @@ module Nextgen
 
       gemfile.save
       cmd = "install"
-      cmd << " --quiet" if noisy_bundler_version?
+      cmd += " --quiet" if noisy_bundler_version?
       bundle_command! cmd
     end
     alias install_gem install_gems

--- a/lib/nextgen/actions/bundler.rb
+++ b/lib/nextgen/actions/bundler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nextgen
   module Actions::Bundler
     def binstubs(*gems)

--- a/lib/nextgen/actions/git.rb
+++ b/lib/nextgen/actions/git.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open3"
 require "securerandom"
 require "shellwords"

--- a/lib/nextgen/actions/yarn.rb
+++ b/lib/nextgen/actions/yarn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nextgen
   module Actions::Yarn
     def add_yarn_packages(*packages, dev: false)

--- a/lib/nextgen/cli.rb
+++ b/lib/nextgen/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thor"
 
 module Nextgen

--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/string/inflections"
 require "fileutils"
 require "forwardable"

--- a/lib/nextgen/ext/prompt/list.rb
+++ b/lib/nextgen/ext/prompt/list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tty-prompt"
 require "tty-screen"
 

--- a/lib/nextgen/ext/prompt/multilist.rb
+++ b/lib/nextgen/ext/prompt/multilist.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tty-prompt"
 
 module Nextgen::Ext

--- a/lib/nextgen/generators.rb
+++ b/lib/nextgen/generators.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yaml"
 
 module Nextgen

--- a/lib/nextgen/generators/action_mailer.rb
+++ b/lib/nextgen/generators/action_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Configure Action Mailer for testing"
 copy_test_support_file "mailer.rb"
 if minitest?

--- a/lib/nextgen/generators/annotate.rb
+++ b/lib/nextgen/generators/annotate.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 install_gem "annotate", group: :development
 copy_file "lib/tasks/auto_annotate_models.rake"

--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Add improved bin/setup script"
 copy_file "bin/setup", mode: :preserve, force: true
 

--- a/lib/nextgen/generators/basic_auth.rb
+++ b/lib/nextgen/generators/basic_auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 document_deploy_var "BASIC_AUTH_PASSWORD"
 document_deploy_var "BASIC_AUTH_USERNAME",
   "If this and `BASIC_AUTH_PASSWORD` are present, visitors must use these credentials to access the app"

--- a/lib/nextgen/generators/brakeman.rb
+++ b/lib/nextgen/generators/brakeman.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 install_gem "brakeman", group: :development, require: false
 binstub "brakeman"

--- a/lib/nextgen/generators/bundler_audit.rb
+++ b/lib/nextgen/generators/bundler_audit.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 install_gem "bundler-audit", group: :development, require: false
 binstub "bundler-audit"

--- a/lib/nextgen/generators/capybara_lockstep.rb
+++ b/lib/nextgen/generators/capybara_lockstep.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 install_gem "capybara-lockstep", group: :test
 inject_into_file "app/views/layouts/application.html.erb",
   "\n    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>",

--- a/lib/nextgen/generators/clean_gemfile.rb
+++ b/lib/nextgen/generators/clean_gemfile.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Nextgen::TidyGemfile.clean!

--- a/lib/nextgen/generators/dotenv.rb
+++ b/lib/nextgen/generators/dotenv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 install_gem "dotenv", version: ">= 3.0", group: %i[development test]
 copy_file ".env.sample"
 gitignore "/.env*", "!/.env.sample"

--- a/lib/nextgen/generators/erb_lint.rb
+++ b/lib/nextgen/generators/erb_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install erb_lint"
 install_gem "erb_lint", group: :development, require: false
 binstub "erb_lint"

--- a/lib/nextgen/generators/eslint.rb
+++ b/lib/nextgen/generators/eslint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install eslint"
 add_yarn_packages(
   "@eslint/js",

--- a/lib/nextgen/generators/factory_bot_rails.rb
+++ b/lib/nextgen/generators/factory_bot_rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install factory_bot_rails"
 install_gem "factory_bot_rails", group: %i[development test]
 

--- a/lib/nextgen/generators/git_safe.rb
+++ b/lib/nextgen/generators/git_safe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Dir.exist?(".git")
   say_git "Mark project as trusted so bin/ can be added to PATH"
   empty_directory ".git/safe"

--- a/lib/nextgen/generators/github_actions.rb
+++ b/lib/nextgen/generators/github_actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 gems = File.exist?("Gemfile") ? File.read("Gemfile").scan(/^\s*gem ["'](.+?)["']/).flatten : []
 template ".github/workflows/ci.yml.tt", context: binding
 copy_file ".github/dependabot.yml"

--- a/lib/nextgen/generators/github_pr_template.rb
+++ b/lib/nextgen/generators/github_pr_template.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 template ".github/PULL_REQUEST_TEMPLATE.md.tt"

--- a/lib/nextgen/generators/good_migrations.rb
+++ b/lib/nextgen/generators/good_migrations.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 install_gem "good_migrations"

--- a/lib/nextgen/generators/home_controller.rb
+++ b/lib/nextgen/generators/home_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 copy_file "app/controllers/home_controller.rb"
 template "app/views/home/index.html.erb.tt"
 route 'root "home#index"'

--- a/lib/nextgen/generators/initial_git_commit.rb
+++ b/lib/nextgen/generators/initial_git_commit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 commit_msg = "tmp/initial_nextgen_commit"
 return unless git_working? && File.exist?(commit_msg)
 

--- a/lib/nextgen/generators/letter_opener.rb
+++ b/lib/nextgen/generators/letter_opener.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install letter_opener"
 install_gem "letter_opener", group: :development
 

--- a/lib/nextgen/generators/node.rb
+++ b/lib/nextgen/generators/node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Add Node and Yarn prerequisites"
 copy_file "package.json" unless File.exist?("package.json")
 inject_into_file "README.md", "\n- Node 18 (LTS) or newer\n- Yarn 1.x (classic)", after: /^- Ruby.*$/

--- a/lib/nextgen/generators/open_browser_on_start.rb
+++ b/lib/nextgen/generators/open_browser_on_start.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install launchy"
 install_gem "launchy", group: %i[development test]
 

--- a/lib/nextgen/generators/overcommit.rb
+++ b/lib/nextgen/generators/overcommit.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 template ".overcommit.yml"

--- a/lib/nextgen/generators/pgcli_rails.rb
+++ b/lib/nextgen/generators/pgcli_rails.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 install_gem "pgcli-rails", group: :development

--- a/lib/nextgen/generators/rack_canonical_host.rb
+++ b/lib/nextgen/generators/rack_canonical_host.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install rack-canonical-host"
 install_gem "rack-canonical-host"
 

--- a/lib/nextgen/generators/rack_mini_profiler.rb
+++ b/lib/nextgen/generators/rack_mini_profiler.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 install_gem "rack-mini-profiler", group: :development
 copy_file "config/initializers/rack_mini_profiler.rb" if File.read("Gemfile").match?(/^\s*gem ['"]turbo-rails['"]/)

--- a/lib/nextgen/generators/rspec_rails.rb
+++ b/lib/nextgen/generators/rspec_rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install the rspec-rails gem"
 install_gem "rspec-rails", group: %i[development test]
 

--- a/lib/nextgen/generators/rspec_system_testing.rb
+++ b/lib/nextgen/generators/rspec_system_testing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 install_gems "capybara", "selenium-webdriver", group: :test
 copy_test_support_file "capybara.rb.tt"
 copy_test_support_file "system.rb"

--- a/lib/nextgen/generators/rubocop.rb
+++ b/lib/nextgen/generators/rubocop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install rubocop gems"
 gemfile = File.read("Gemfile")
 plugins = []

--- a/lib/nextgen/generators/shoulda.rb
+++ b/lib/nextgen/generators/shoulda.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install shoulda gems"
 install_gem "shoulda-context", group: :test if minitest?
 install_gem "shoulda-matchers", group: :test

--- a/lib/nextgen/generators/sidekiq.rb
+++ b/lib/nextgen/generators/sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install the sidekiq gem in the :production group, with a binstub"
 install_gem "sidekiq", version: "~> 7.0", group: :production
 binstub "sidekiq"

--- a/lib/nextgen/generators/staging.rb
+++ b/lib/nextgen/generators/staging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 copy_file "config/environments/staging.rb"
 gsub_file "DEPLOYMENT.md", '"production"', '"production" or "staging"' if File.exist?("DEPLOYMENT.md")
 

--- a/lib/nextgen/generators/stylelint.rb
+++ b/lib/nextgen/generators/stylelint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install stylelint"
 add_yarn_packages(
   "stylelint",

--- a/lib/nextgen/generators/thor.rb
+++ b/lib/nextgen/generators/thor.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 copy_file "Thorfile"
 binstub "thor"

--- a/lib/nextgen/generators/tomo.rb
+++ b/lib/nextgen/generators/tomo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install the tomo gem in the :development group, with a binstub"
 install_gem "tomo", version: "~> 1.18", group: :development, require: false
 binstub "tomo"

--- a/lib/nextgen/generators/vcr.rb
+++ b/lib/nextgen/generators/vcr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 install_gems "vcr", "webmock", group: :test
 copy_test_support_file "vcr.rb.tt"
 copy_test_support_file "webmock.rb"

--- a/lib/nextgen/generators/vite.rb
+++ b/lib/nextgen/generators/vite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 say_git "Install the vite_rails gem"
 install_gem "vite_rails", version: "~> 3.0"
 

--- a/lib/nextgen/rails.rb
+++ b/lib/nextgen/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/version"
 
 module Nextgen

--- a/lib/nextgen/rails_options.rb
+++ b/lib/nextgen/rails_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nextgen
   class RailsOptions
     DATABASES = %w[

--- a/lib/nextgen/thor_extensions.rb
+++ b/lib/nextgen/thor_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nextgen
   module ThorExtensions
     def self.extended(base)

--- a/lib/nextgen/tidy_gemfile.rb
+++ b/lib/nextgen/tidy_gemfile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nextgen
   class TidyGemfile
     def self.clean!(path = "Gemfile")

--- a/lib/nextgen/tidy_gemfile.rb
+++ b/lib/nextgen/tidy_gemfile.rb
@@ -64,8 +64,8 @@ module Nextgen
 
     def build_gem_line(gem, version:, require:, indent:)
       line = %(gem "#{gem}")
-      line << ", #{version.to_s.inspect}" if version
-      line << ", require: #{require.inspect}" unless require.nil?
+      line += ", #{version.to_s.inspect}" if version
+      line += ", require: #{require.inspect}" unless require.nil?
 
       indent + line + "\n"
     end

--- a/lib/nextgen/version.rb
+++ b/lib/nextgen/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nextgen
-  VERSION = "0.14.0".freeze
+  VERSION = "0.14.0"
 end

--- a/nextgen.gemspec
+++ b/nextgen.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/nextgen/version"
 
 Gem::Specification.new do |spec|

--- a/template/.erb-lint.yml.tt
+++ b/template/.erb-lint.yml.tt
@@ -22,4 +22,6 @@ linters:
         Enabled: false
       Rails/OutputSafety:
         Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
 <% end -%>

--- a/template/.rubocop.yml.tt
+++ b/template/.rubocop.yml.tt
@@ -223,9 +223,6 @@ Style/FetchEnvVar:
 Style/FormatStringToken:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/GuardClause:
   Enabled: false
 

--- a/template/Thorfile
+++ b/template/Thorfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "config/environment" unless %w[-h --help help -T list -v version].include?(ARGV.first)
 
 class << Thor

--- a/template/app/controllers/concerns/basic_auth.rb
+++ b/template/app/controllers/concerns/basic_auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BasicAuth
   extend ActiveSupport::Concern
 

--- a/template/app/controllers/home_controller.rb
+++ b/template/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HomeController < ApplicationController
   def index
   end

--- a/template/app/helpers/inline_svg_helper.rb
+++ b/template/app/helpers/inline_svg_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InlineSvgHelper
   def inline_svg_tag(filename, title: nil)
     svg = ViteInlineSvgFileLoader.named(filename)

--- a/template/bin/setup
+++ b/template/bin/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # This script is a way to set up or update your development environment automatically.
 # This script is idempotent, so that you can run it at any time and get an expectable outcome.

--- a/template/config/environments/staging.rb
+++ b/template/config/environments/staging.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # The staging environment is based on production
 require_relative "production"

--- a/template/config/initializers/generators.rb
+++ b/template/config/initializers/generators.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.config.generators do |g|
   # Disable generators we don't need.
   g.javascripts false

--- a/template/config/initializers/rack_mini_profiler.rb
+++ b/template/config/initializers/rack_mini_profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 return unless defined?(Rack::MiniProfiler)
 
 # https://github.com/MiniProfiler/rack-mini-profiler#configuration-options

--- a/template/config/initializers/sidekiq.rb
+++ b/template/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 return unless defined?(Sidekiq)
 
 # Disable SSL certificate verification if using Heroku Redis

--- a/template/lib/puma/plugin/open.rb
+++ b/template/lib/puma/plugin/open.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "puma/plugin"
 
 Puma::Plugin.create do

--- a/template/lib/tasks/auto_annotate_models.rake
+++ b/template/lib/tasks/auto_annotate_models.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 return unless Rails.env.development?
 
 require "annotate"

--- a/template/lib/tasks/erblint.rake
+++ b/template/lib/tasks/erblint.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Run erblint"
 task :erblint do
   sh "bin/erblint --lint-all"

--- a/template/lib/tasks/eslint.rake
+++ b/template/lib/tasks/eslint.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Run ESLint"
 task :eslint do
   sh "yarn lint:js"

--- a/template/lib/tasks/rubocop.rake
+++ b/template/lib/tasks/rubocop.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 return unless Gem.loaded_specs.key?("rubocop")
 
 require "rubocop/rake_task"

--- a/template/lib/tasks/stylelint.rake
+++ b/template/lib/tasks/stylelint.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Run Stylelint"
 task :stylelint do
   sh "yarn lint:css"

--- a/template/lib/templates/rspec/system/system_spec.rb
+++ b/template/lib/templates/rspec/system/system_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "<%= class_name %>" do

--- a/template/lib/vite_inline_svg_file_loader.rb
+++ b/template/lib/vite_inline_svg_file_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ViteInlineSvgFileLoader
   class << self
     def named(filename)

--- a/template/spec/support/factory_bot.rb
+++ b/template/spec/support/factory_bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end

--- a/template/spec/support/mailer.rb
+++ b/template/spec/support/mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before(:each) do
     ActionMailer::Base.deliveries.clear

--- a/template/spec/support/shoulda.rb
+++ b/template/spec/support/shoulda.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec

--- a/template/spec/support/system.rb
+++ b/template/spec/support/system.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium,

--- a/template/spec/support/webmock.rb
+++ b/template/spec/support/webmock.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "webmock/rspec"

--- a/template/test/application_system_test_case.rb
+++ b/template/test/application_system_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase

--- a/template/test/helpers/inline_svg_helper_test.rb
+++ b/template/test/helpers/inline_svg_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "vite_helper"
 

--- a/template/test/support/capybara.rb.tt
+++ b/template/test/support/capybara.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "capybara/rails"
 <% if rspec? -%>
 require "capybara/rspec"

--- a/template/test/support/factory_bot.rb
+++ b/template/test/support/factory_bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveSupport.on_load(:active_support_test_case) do
   include FactoryBot::Syntax::Methods
 end

--- a/template/test/support/mailer.rb
+++ b/template/test/support/mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveSupport.on_load(:active_support_test_case) do
   setup { ActionMailer::Base.deliveries.clear }
 end

--- a/template/test/support/shoulda.rb
+++ b/template/test/support/shoulda.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :minitest

--- a/template/test/support/vcr.rb.tt
+++ b/template/test/support/vcr.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "vcr"
 
 VCR.configure do |config|

--- a/template/test/support/webmock.rb
+++ b/template/test/support/webmock.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "webmock/minitest"

--- a/template/test/vite_helper.rb
+++ b/template/test/vite_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 return if ViteRuby.config.auto_build
 
 # Compile assets once at the start of testing

--- a/test/e2e/nextgen_e2e_test.rb
+++ b/test/e2e/nextgen_e2e_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "fileutils"
 require "open3"

--- a/test/integration/generators/github_actions_test.rb
+++ b/test/integration/generators/github_actions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_case"
 
 class Nextgen::Generators::GithubActionsTest < Nextgen::Generators::TestCase

--- a/test/integration/generators/github_pr_template_test.rb
+++ b/test/integration/generators/github_pr_template_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_case"
 
 class Nextgen::Generators::GithubPrTemplateTest < Nextgen::Generators::TestCase

--- a/test/integration/generators/rspec_system_testing_test.rb
+++ b/test/integration/generators/rspec_system_testing_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_case"
 
 class Nextgen::Generators::RspecSystemTestingTest < Nextgen::Generators::TestCase

--- a/test/integration/generators/rubocop_test.rb
+++ b/test/integration/generators/rubocop_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_case"
 
 class Nextgen::Generators::RubocopTest < Nextgen::Generators::TestCase

--- a/test/integration/generators/staging_test.rb
+++ b/test/integration/generators/staging_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_case"
 
 class Nextgen::Generators::StagingTest < Nextgen::Generators::TestCase

--- a/test/integration/generators/test_case.rb
+++ b/test/integration/generators/test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "securerandom"
 require "tmpdir"

--- a/test/integration/generators/vcr_test.rb
+++ b/test/integration/generators/vcr_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_case"
 
 class Nextgen::Generators::VcrTest < Nextgen::Generators::TestCase

--- a/test/nextgen/rails_options_test.rb
+++ b/test/nextgen/rails_options_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Nextgen::RailsOptionsTest < Minitest::Test

--- a/test/nextgen_test.rb
+++ b/test/nextgen_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class NextgenTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "nextgen"
 


### PR DESCRIPTION
Apparently Ruby 4 will freeze string literals by default. In preparation for that breaking change, Ruby 3.4 will issue a warning when string literals are mutated.

To prepare nextgen and nextgen-generated apps for the Ruby 4 future, I've added the `frozen_string_literal` comment to all files to opt into this behavior. For apps that opt into RuboCop, I've enabled the `Style/FrozenStringLiteralComment` rule by default as well.