### PR TITLE
Use `yarn install --check-files` instead of deprecated `yarn check`

### DIFF
--- a/template/bin/setup
+++ b/template/bin/setup
@@ -9,7 +9,7 @@ def setup!
   run "bundle install" if bundle_needed?
   run "overcommit --install" if overcommit_installable?
   run "bin/rails db:prepare" if database_present?
-  run "yarn install" if yarn_needed?
+  run "yarn install --check-files" if yarn_needed?
   run "bin/rails tmp:create" if tmp_missing?
   run "bin/rails restart"
 
@@ -49,7 +49,7 @@ def database_present?
 end
 
 def yarn_needed?
-  File.exist?("yarn.lock") && !run("yarn check --check-files", silent: true, exception: false)
+  File.exist?("yarn.lock")
 end
 
 def tmp_missing?


### PR DESCRIPTION
https://classic.yarnpkg.com/lang/en/docs/cli/check/

> NOTE: The command `yarn check` has been historically buggy and undermaintained and, as such, [has been deprecated and will be removed in Yarn 2.0](https://github.com/yarnpkg/rfcs/pull/106). You should use `yarn install --check-files` instead.