### PR TITLE
Fix `uninitialized constant Thor` in generated Rakefile under Rails 7.2

### DIFF
--- a/lib/nextgen/actions.rb
+++ b/lib/nextgen/actions.rb
@@ -119,7 +119,7 @@ module Nextgen
 
           desc "Apply auto-corrections"
           task fix: %w[] do
-            Thor::Base.shell.new.say_status :OK, "All fixes applied!"
+            puts ">>>>>> [OK] All fixes applied!"
           end
         RUBY
       end

--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -23,7 +23,7 @@ append_to_file "Rakefile", <<~RUBY
 
   desc "Run all checks"
   task default: %w[#{test_task}] do
-    Thor::Base.shell.new.say_status :OK, "All checks passed!"
+    puts ">>>>>> [OK] All checks passed!"
   end
 RUBY
 


### PR DESCRIPTION
Starting in Rails 7.2, it seems that thor is no longer automatically loaded when running `bin/rake`. The `Rakefile` generated by nextgen was expecting the `Thor` constant to be present, leading to a "uninitialized constant Thor" error when running under Rails 7.2.0.beta3.

Fix by removing the Thor reference from the generated Rakefile.