### PR TITLE
Standardize on bin/dev for running Rails app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Nextgen can optionally install and configure these Node packages to work nicely 
 [Vite](https://vitejs.dev) (pronounced _veet_) is a next generation Node-based frontend build system and hot-reloading dev server. It can completely take the place of the asset pipeline and integrate seamlessly with Rails via the [vite_rails](https://github.com/ElMassimo/vite_ruby) gem. If you opt-in, Nextgen can set you up with Vite and adds a bunch of vite_rails best practices:
 
 - All frontend sources (CSS, JS, images) are moved to `app/frontend`
-- A `yarn start` script is used to start the Rails server and Vite dev server
+- A `bin/dev` script is used to start the Rails server and Vite dev server
 - The [autoprefixer](https://github.com/postcss/autoprefixer) package is installed and activated via PostCSS
 - A base set of CSS files are added, including [modern_normalize](https://github.com/sindresorhus/modern-normalize)
 - A Vite-compatible inline SVG helper is added

--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -15,6 +15,11 @@ copy_file "DEPLOYMENT.md"
 say_git "Create a Procfile"
 template "Procfile.tt"
 
+unless File.exist?("bin/dev")
+  say_git "Create bin/dev script"
+  copy_file "bin/dev", mode: :preserve
+end
+
 say_git "Set up default rake task"
 test_task = "test:all" if minitest?
 append_to_file "Rakefile", <<~RUBY

--- a/lib/nextgen/generators/vite.rb
+++ b/lib/nextgen/generators/vite.rb
@@ -96,8 +96,7 @@ say_git "Add a `yarn start` script"
 start = "concurrently -i -k --kill-others-on-fail -p none 'RUBY_DEBUG_OPEN=true bin/rails s' 'bin/vite dev'"
 add_package_json_script(start:)
 add_yarn_package "concurrently", dev: true
-gsub_file "README.md", %r{bin/rails s(erver)?}, "yarn start"
-gsub_file "bin/setup", %r{bin/rails s(erver)?}, "yarn start"
+copy_file "bin/dev-yarn", "bin/dev", mode: :preserve, force: true
 remove_file "Procfile.dev"
 
 say_git "Add Safari cache workaround in development"

--- a/template/README.md.tt
+++ b/template/README.md.tt
@@ -38,7 +38,7 @@ bin/setup
 Start the Rails server with this command:
 
 ```
-bin/rails s
+bin/dev
 ```
 
 The app will be located at <http://localhost:3000/>.

--- a/template/bin/dev
+++ b/template/bin/dev
@@ -1,2 +1,4 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 exec "./bin/rails", "server", *ARGV

--- a/template/bin/dev
+++ b/template/bin/dev
@@ -1,3 +1,2 @@
-#!/usr/bin/env sh
-
-exec bin/rails server "$@"
+#!/usr/bin/env ruby
+exec "./bin/rails", "server", *ARGV

--- a/template/bin/dev
+++ b/template/bin/dev
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec bin/rails server "$@"

--- a/template/bin/dev-yarn
+++ b/template/bin/dev-yarn
@@ -1,3 +1,2 @@
-#!/usr/bin/env sh
-
-exec yarn start "$@"
+#!/usr/bin/env ruby
+exec "yarn", "start", *ARGV

--- a/template/bin/dev-yarn
+++ b/template/bin/dev-yarn
@@ -1,2 +1,4 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 exec "yarn", "start", *ARGV

--- a/template/bin/dev-yarn
+++ b/template/bin/dev-yarn
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec yarn start "$@"

--- a/template/bin/setup
+++ b/template/bin/setup
@@ -20,7 +20,7 @@ def setup!
   end
 
   say_status :Ready!,
-    "Use #{colorize("bin/rails s", :yellow)} to start the app, " \
+    "Use #{colorize("bin/dev", :yellow)} to start the app, " \
     "or #{colorize("bin/rake", :yellow)} to run tests"
 end
 


### PR DESCRIPTION
Rails 8 will add `bin/dev` to all Rails apps, even those that don't use esbuild/webpack/vite/etc. This makes `bin/dev` the standard way to run Rails apps locally, regardless of tech stack.

Let's get ahead of this by adopting it in nextgen. For non-Vite apps, nextgen will generate a `bin/dev` script inspired by the Rails 8 default. For Vite apps, `bin/dev` will delegate to `yarn start`.