### PR TITLE
Disable `Rails/LinkToBlank` rubocop rule

### DIFF
--- a/template/.rubocop.yml.tt
+++ b/template/.rubocop.yml.tt
@@ -178,6 +178,9 @@ Rails/I18nLocaleTexts:
 Rails/Inquiry:
   Enabled: false
 
+Rails/LinkToBlank:
+  Enabled: false
+
 Rails/NotNullColumn:
   Enabled: false
 


### PR DESCRIPTION
Modern browsers automatically treat `target=_blank` links as though they also have `rel=noopener`. So the `Rails/LinkToBlank` rule is no longer relevant.

https://mathiasbynens.github.io/rel-noopener/