### PR TITLE
Allow new Rails 7.2 built-ins to be skipped (brakeman, rubocop, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Nextgen is an **interactive** and flexible alternative to `rails new` that inclu
 
 ## Requirements
 
-Nextgen generates apps using **Rails 7.1**.
+Nextgen generates apps using **Rails 7.2**.
 
 - **Ruby 3.1+** is required
 - **Rubygems 3.4.8+** is required (run `gem update --system` to get it)

--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -45,6 +45,7 @@ module Nextgen
       ask_frontend_management unless rails_opts.api?
       ask_css unless rails_opts.api? || rails_opts.skip_asset_pipeline?
       ask_javascript unless rails_opts.api? || rails_opts.skip_asset_pipeline?
+      ask_rails_tools
       ask_rails_frameworks
       ask_test_framework
       ask_system_testing if rails_opts.frontend? && rails_opts.test_framework?
@@ -196,6 +197,22 @@ module Nextgen
       )
     end
 
+    def ask_rails_tools
+      tools = {
+        "Brakeman" => "brakeman",
+        "GitHub Actions CI" => "ci",
+        "RuboCop (rubocop-rails-omakase)" => "rubocop"
+      }
+
+      answers = prompt.multi_select(
+        "Rails 7.2 can preinstall the following. Which do you need?",
+        tools,
+        default: tools.keys.reverse
+      )
+
+      (tools.values - answers).each { rails_opts.skip_optional_feature!(_1) }
+    end
+
     def ask_rails_frameworks
       frameworks = {
         "JBuilder" => "jbuilder",
@@ -222,7 +239,7 @@ module Nextgen
         default: frameworks.keys.reverse
       )
 
-      (frameworks.values - answers).each { rails_opts.skip_optional_framework!(_1) }
+      (frameworks.values - answers).each { rails_opts.skip_optional_feature!(_1) }
     end
 
     def ask_test_framework

--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -198,19 +198,23 @@ module Nextgen
     end
 
     def ask_rails_tools
-      tools = {
+      opt_out = {
         "Brakeman" => "brakeman",
         "GitHub Actions CI" => "ci",
         "RuboCop (rubocop-rails-omakase)" => "rubocop"
       }
+      opt_in = {
+        "devcontainer files" => "devcontainer"
+      }
 
       answers = prompt.multi_select(
         "Rails can preinstall the following. Which do you need?",
-        tools,
-        default: tools.keys.reverse
+        opt_out.merge(opt_in),
+        default: opt_out.keys.reverse
       )
 
-      (tools.values - answers).each { rails_opts.skip_optional_feature!(_1) }
+      rails_opts.devcontainer! if answers.delete("devcontainer")
+      (opt_out.values - answers).each { rails_opts.skip_optional_feature!(_1) }
     end
 
     def ask_rails_frameworks

--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -205,7 +205,7 @@ module Nextgen
       }
 
       answers = prompt.multi_select(
-        "Rails 7.2 can preinstall the following. Which do you need?",
+        "Rails can preinstall the following. Which do you need?",
         tools,
         default: tools.keys.reverse
       )

--- a/lib/nextgen/rails_options.rb
+++ b/lib/nextgen/rails_options.rb
@@ -38,6 +38,7 @@ module Nextgen
     def initialize
       @api = false
       @edge = false
+      @devcontainer = nil
       @skip_features = []
       @skip_system_test = false
       @test_framework = "minitest"
@@ -100,6 +101,10 @@ module Nextgen
 
     def edge?
       @edge
+    end
+
+    def devcontainer!
+      @devcontainer = true
     end
 
     def api!
@@ -186,6 +191,7 @@ module Nextgen
         args << "--database=#{database}" if database
         args << "--css=#{css}" if css
         args << "--javascript=#{javascript}" if javascript
+        args << "--devcontainer" if @devcontainer
         args.push(*skip_features.map { "--skip-#{_1.tr("_", "-")}" })
       end
     end

--- a/lib/nextgen/rails_options.rb
+++ b/lib/nextgen/rails_options.rb
@@ -19,15 +19,18 @@ module Nextgen
 
     ASSET_PIPELINES = %w[sprockets propshaft].freeze
 
-    OPTIONAL_FRAMEWORKS = %w[
+    OPTIONAL_FEATURES = %w[
       action_mailer
       action_mailbox
       action_text
       active_job
       active_storage
       action_cable
+      brakeman
+      ci
       hotwire
       jbuilder
+      rubocop
     ].freeze
 
     attr_reader :asset_pipeline, :css, :javascript, :database, :test_framework
@@ -35,7 +38,7 @@ module Nextgen
     def initialize
       @api = false
       @edge = false
-      @skip_frameworks = []
+      @skip_features = []
       @skip_system_test = false
       @test_framework = "minitest"
     end
@@ -151,23 +154,23 @@ module Nextgen
     end
 
     def action_mailer?
-      !skip_optional_framework?("action_mailer")
+      !skip_optional_feature?("action_mailer")
     end
 
     def active_job?
-      !skip_optional_framework?("active_job")
+      !skip_optional_feature?("active_job")
     end
 
-    def skip_optional_framework!(framework)
-      raise ArgumentError, "Unknown framework: #{framework}" unless OPTIONAL_FRAMEWORKS.include?(framework)
+    def skip_optional_feature!(feature)
+      raise ArgumentError, "Unknown feature: #{feature}" unless OPTIONAL_FEATURES.include?(feature)
 
-      skip_frameworks << framework
+      skip_features << feature
     end
 
-    def skip_optional_framework?(framework)
-      raise ArgumentError, "Unknown framework: #{framework}" unless OPTIONAL_FRAMEWORKS.include?(framework)
+    def skip_optional_feature?(feature)
+      raise ArgumentError, "Unknown feature: #{feature}" unless OPTIONAL_FEATURES.include?(feature)
 
-      skip_frameworks.include?(framework)
+      skip_features.include?(feature)
     end
 
     def to_args # rubocop:disable Metrics/PerceivedComplexity
@@ -183,12 +186,12 @@ module Nextgen
         args << "--database=#{database}" if database
         args << "--css=#{css}" if css
         args << "--javascript=#{javascript}" if javascript
-        args.push(*skip_frameworks.map { "--skip-#{_1.tr("_", "-")}" })
+        args.push(*skip_features.map { "--skip-#{_1.tr("_", "-")}" })
       end
     end
 
     private
 
-    attr_reader :skip_frameworks
+    attr_reader :skip_features
   end
 end

--- a/nextgen.gemspec
+++ b/nextgen.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", "~> 7.1.1"
+  spec.add_dependency "railties", ">= 7.2.0.rc1", "< 7.3"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "tty-prompt", "~> 0.23.1"
   spec.add_dependency "tty-screen", "~> 0.8.1"

--- a/test/e2e/nextgen_e2e_test.rb
+++ b/test/e2e/nextgen_e2e_test.rb
@@ -7,15 +7,15 @@ require "securerandom"
 
 class NextgenE2ETest < Minitest::Test
   def test_nextgen_generates_rails_app
-    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\n\n\n\n\n\n\u0001\n\n")
+    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\n\n\n\n\n\n\n\u0001\n\n")
   end
 
   def test_nextgen_generates_vite_rails_app
-    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\e[B\e[B\n\n\n\n\u0001\n\n")
+    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\e[B\e[B\n\n\n\n\n\u0001\n\n")
   end
 
   def test_nextgen_generates_rspec_rails_app
-    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\n\n\n\n\e[B\n\n\u0001\n\n")
+    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\n\n\n\n\n\e[B\n\n\u0001\n\n")
   end
 
   private

--- a/test/nextgen/rails_options_test.rb
+++ b/test/nextgen/rails_options_test.rb
@@ -206,6 +206,13 @@ class Nextgen::RailsOptionsTest < Minitest::Test
     assert_equal(["--skip-system-test"], opts.to_args)
   end
 
+  def test_devcontainer_is_opt_in
+    opts = Nextgen::RailsOptions.new
+    opts.devcontainer!
+
+    assert_equal(["--devcontainer"], opts.to_args)
+  end
+
   def test_defaults
     opts = Nextgen::RailsOptions.new
 

--- a/test/nextgen/rails_options_test.rb
+++ b/test/nextgen/rails_options_test.rb
@@ -134,14 +134,17 @@ class Nextgen::RailsOptionsTest < Minitest::Test
 
   def test_optional_frameworks_can_be_skipped
     opts = Nextgen::RailsOptions.new
-    opts.skip_optional_framework!("action_mailer")
-    opts.skip_optional_framework!("action_mailbox")
-    opts.skip_optional_framework!("action_text")
-    opts.skip_optional_framework!("active_job")
-    opts.skip_optional_framework!("active_storage")
-    opts.skip_optional_framework!("action_cable")
-    opts.skip_optional_framework!("hotwire")
-    opts.skip_optional_framework!("jbuilder")
+    opts.skip_optional_feature!("action_mailer")
+    opts.skip_optional_feature!("action_mailbox")
+    opts.skip_optional_feature!("action_text")
+    opts.skip_optional_feature!("active_job")
+    opts.skip_optional_feature!("active_storage")
+    opts.skip_optional_feature!("action_cable")
+    opts.skip_optional_feature!("brakeman")
+    opts.skip_optional_feature!("ci")
+    opts.skip_optional_feature!("hotwire")
+    opts.skip_optional_feature!("jbuilder")
+    opts.skip_optional_feature!("rubocop")
 
     assert_equal(
       %w[
@@ -151,8 +154,11 @@ class Nextgen::RailsOptionsTest < Minitest::Test
         --skip-active-job
         --skip-active-storage
         --skip-action-cable
+        --skip-brakeman
+        --skip-ci
         --skip-hotwire
         --skip-jbuilder
+        --skip-rubocop
       ],
       opts.to_args
     )
@@ -161,7 +167,7 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   def test_invalid_optional_frameworks_raises
     opts = Nextgen::RailsOptions.new
 
-    assert_raises(ArgumentError) { opts.skip_optional_framework!("action_blah") }
+    assert_raises(ArgumentError) { opts.skip_optional_feature!("action_blah") }
   end
 
   def test_test_framework_can_be_set_to_minitest


### PR DESCRIPTION
Rails 7.2 can preinstall a handful of new gems and configuration. All are enabled by default except for `--devcontainer`, which is opt-in.

```
Rails can preinstall the following. Which do you need?
‣ ⬢ Brakeman
  ⬢ GitHub Actions CI
  ⬢ RuboCop (rubocop-rails-omakase)
  ⬡ devcontainer files
```