### PR TITLE
Allow vite option to be used with Rails 7.2

### DIFF
--- a/lib/nextgen/actions/yarn.rb
+++ b/lib/nextgen/actions/yarn.rb
@@ -22,6 +22,12 @@ module Nextgen
     end
     alias add_package_json_script add_package_json_scripts
 
+    def remove_package_json_script(name)
+      cmd = "npm pkg delete scripts.#{name.to_s.shellescape}"
+      say_status :run, cmd.truncate(60), :green
+      run! cmd, verbose: false
+    end
+
     def yarn_command(cmd, capture: false)
       say_status :yarn, cmd, :green
       output = run! "yarn #{cmd}", capture: true, verbose: false

--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -166,8 +166,7 @@ module Nextgen
       )
 
       if frontend == :vite
-        rails_opts.asset_pipeline = nil
-        rails_opts.javascript = "vite"
+        rails_opts.vite!
       else
         rails_opts.asset_pipeline = frontend
       end

--- a/lib/nextgen/generators/vite.rb
+++ b/lib/nextgen/generators/vite.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+say_git "Remove esbuild"
+remove_yarn_package "esbuild"
+remove_package_json_script(:build)
+
 say_git "Install the vite_rails gem"
 install_gem "vite_rails", version: "~> 3.0"
 

--- a/lib/nextgen/rails_options.rb
+++ b/lib/nextgen/rails_options.rb
@@ -38,6 +38,7 @@ module Nextgen
     def initialize
       @api = false
       @edge = false
+      @vite = false
       @devcontainer = nil
       @skip_features = []
       @skip_system_test = false
@@ -59,16 +60,19 @@ module Nextgen
 
     def javascript=(framework)
       raise ArgumentError, "Can't specify javascript in API mode" if api? && framework
-
-      if skip_asset_pipeline? && framework != "vite"
-        raise ArgumentError, "Can't specify javascript when asset pipeline is disabled"
-      end
+      raise ArgumentError, "Can't specify javascript when asset pipeline is disabled" if skip_asset_pipeline?
 
       @javascript = framework
     end
 
+    def vite!
+      self.asset_pipeline = nil
+      @javascript = "esbuild"
+      @vite = true
+    end
+
     def vite?
-      @javascript == "vite"
+      @vite
     end
 
     def skip_javascript?
@@ -123,7 +127,7 @@ module Nextgen
     end
 
     def requires_node?
-      %w[bootstrap bulma postcss sass].include?(css) || %w[webpack esbuild rollup vite].include?(javascript)
+      %w[bootstrap bulma postcss sass].include?(css) || %w[webpack esbuild rollup].include?(javascript)
     end
 
     def rspec?

--- a/test/nextgen/rails_options_test.rb
+++ b/test/nextgen/rails_options_test.rb
@@ -48,7 +48,7 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_node_requirement_depends_on_javascript_option
-    %w[webpack esbuild rollup vite].each do |js|
+    %w[webpack esbuild rollup].each do |js|
       opts = Nextgen::RailsOptions.new
       opts.javascript = js
 
@@ -99,16 +99,22 @@ class Nextgen::RailsOptionsTest < Minitest::Test
     assert_raises(ArgumentError) { opts.asset_pipeline = "something" }
   end
 
-  def test_assigning_nil_disables_asset_pipeline_allows_vite_but_prohibits_other_frontend_options
+  def test_assigning_nil_disables_asset_pipeline_allows_and_prohibits_other_frontend_options
     opts = Nextgen::RailsOptions.new
     opts.asset_pipeline = nil
 
     assert_prohibited { opts.css = "sass" }
-    assert_prohibited { opts.javascript = "esbuild" }
+    assert_prohibited { opts.javascript = "rollup" }
+  end
 
-    opts.javascript = "vite"
-    assert(opts.skip_asset_pipeline?)
-    assert_equal(["--skip-asset-pipeline", "--javascript=vite"], opts.to_args)
+  def test_vite_disables_asset_pipeline_and_uses_esbuild_under_the_hood
+    opts = Nextgen::RailsOptions.new
+
+    refute_predicate opts, :vite?
+
+    opts.vite!
+    assert_predicate opts, :vite?
+    assert_equal(%w[--skip-asset-pipeline --javascript=esbuild], opts.to_args)
   end
 
   def test_assigning_nil_database_disables_active_record


### PR DESCRIPTION
The Rails `--javascript` option no longer accepts "vite" as a value. We were using this before to tell Rails to enable JavaScript, but skip any actual framework installation, since "vite" was not a recognized value.

However in Rails 7.2, the `--javascript` option is more strictly validated, such that "vite" is no longer allowed.

We can't use `--skip-javascript`, because then things like turbo would also get skipped. So we have to pass _something_ as the JS framework.

Fix by passing "esbuild" instead. This tells Rails that we are using a Node-based build step. Then when we install Vite, delete the esbuild stuff that was added.