### PR TITLE
Offer option to replace rubocop-rails-omakase with custom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ If you've opted into GitHub Actions, Nextgen will automatically add jobs to your
 
 Prefer RSpec? Nextgen can set you up with RSpec, plus the gems and configuration you need for system specs (browser testing). Or stick with the Rails Minitest defaults. In either case, Nextgen will set up a good default Rake task and appropriate CI job.
 
+### Opinionated RuboCop Config
+
+By default, Rails apps include RuboCop with a config defined by the [rubocop-rails-omakase](https://github.com/rails/rubocop-rails-omakase) gem. Nextgen allows you to opt out of RuboCop entirely, or use Nextgen's own custom RuboCop config. Nextgen's config will automatically include Capybara, FactoryBot, and RSpec rules, should your app include those frameworks.
+
 ### Gems
 
 Nextgen can install and configure your choice of these recommended gems:
@@ -87,7 +91,6 @@ Nextgen can install and configure your choice of these recommended gems:
 - [pgcli-rails](https://github.com/mattbrictson/pgcli-rails)
 - [rack-canonical-host](https://github.com/tylerhunt/rack-canonical-host)
 - [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler)
-- [rubocop](https://github.com/rubocop/rubocop)
 - [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers)
 - [sidekiq](https://github.com/sidekiq/sidekiq)
 - [thor](https://github.com/rails/thor)

--- a/config/generators.yml
+++ b/config/generators.yml
@@ -139,8 +139,9 @@ vcr:
   requires: test_framework
 
 rubocop:
-  prompt: "RuboCop"
-  description: "Install rubocop gems; apply formatting rules"
+  prompt: "RuboCop (nextgen custom config)"
+  description: "Replace rubocop-rails-omakase with a custom config"
+  requires: rubocop
 
 overcommit:
   prompt: "Overcommit"

--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -200,7 +200,7 @@ module Nextgen
       opt_out = {
         "Brakeman" => "brakeman",
         "GitHub Actions CI" => "ci",
-        "RuboCop (rubocop-rails-omakase)" => "rubocop"
+        "RuboCop" => "rubocop"
       }
       opt_in = {
         "devcontainer files" => "devcontainer"

--- a/lib/nextgen/generators/rubocop.rb
+++ b/lib/nextgen/generators/rubocop.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 say_git "Install rubocop gems"
+remove_gem "rubocop-rails-omakase"
 gemfile = File.read("Gemfile")
 plugins = []
 plugins << "capybara" if gemfile.match?(/^\s*gem ['"]capybara['"]/)
@@ -12,8 +13,8 @@ install_gem("rubocop-rails", version: ">= 2.22.0", group: :development, require:
 install_gems(*plugins.map { "rubocop-#{_1}" }, "rubocop", group: :development, require: false)
 binstub "rubocop"
 
-say_git "Generate .rubocop.yml"
-template ".rubocop.yml", context: binding
+say_git "Replace .rubocop.yml"
+template ".rubocop.yml", context: binding, force: true
 
 if File.exist?(".erb-lint.yml")
   say_git "Regenerate .erb-lint.yml with rubocop support"

--- a/lib/nextgen/rails_options.rb
+++ b/lib/nextgen/rails_options.rb
@@ -134,6 +134,10 @@ module Nextgen
       @test_framework == "rspec"
     end
 
+    def rubocop?
+      !skip_optional_feature?("rubocop")
+    end
+
     def active_record?
       !skip_active_record?
     end


### PR DESCRIPTION
Rails 7.2 now includes rubocop and an opinionated config via the `rubocop-rails-omakase` gem.

Nextgen has historically provided its own custom rubocop config.

Update our generators so that we continue to offer Nextgen's rubocop config to users who want it. In this case the `rubocop-rails-omakase` gem will be removed.