### PR TITLE
Update generated README with new Rails 7.2+ puma defaults

### DIFF
--- a/template/DEPLOYMENT.md
+++ b/template/DEPLOYMENT.md
@@ -6,6 +6,6 @@ These environment variables affect how the app functions when deployed in produc
 
 - `RAILS_DISABLE_SSL` - Disable HSTS and secure cookies
 - `RAILS_ENV` **REQUIRED** - "production"
-- `RAILS_MAX_THREADS` - Number of threads per Puma process (default: 5)
+- `RAILS_MAX_THREADS` - Number of threads per Puma process (default: 3)
 - `SECRET_KEY_BASE` **REQUIRED** - Unique, secret key used to encrypt and sign cookies and other sensitive data
 - `WEB_CONCURRENCY` - Number of Puma processes (default: number of CPUs)

--- a/test/integration/generators/staging_test.rb
+++ b/test/integration/generators/staging_test.rb
@@ -15,7 +15,7 @@ class Nextgen::Generators::StagingTest < Nextgen::Generators::TestCase
     File.write(File.join(destination_root, "DEPLOYMENT.md"), <<~DEPLOYMENT_MD)
       - `RAILS_DISABLE_SSL` - Disable HSTS and secure cookies
       - `RAILS_ENV` **REQUIRED** - "production"
-      - `RAILS_MAX_THREADS` - Number of threads per Puma process (default: 5)
+      - `RAILS_MAX_THREADS` - Number of threads per Puma process (default: 3)
     DEPLOYMENT_MD
 
     apply_generator


### PR DESCRIPTION
The puma config included with the latest versions of Rails now default to 3 threads.