### PR TITLE
Don't generate `bin/rubocop` if Rails has already provided it

### DIFF
--- a/lib/nextgen/generators/rubocop.rb
+++ b/lib/nextgen/generators/rubocop.rb
@@ -11,7 +11,7 @@ plugins << "performance"
 plugins << "rails"
 install_gem("rubocop-rails", version: ">= 2.22.0", group: :development, require: false)
 install_gems(*plugins.map { "rubocop-#{_1}" }, "rubocop", group: :development, require: false)
-binstub "rubocop"
+binstub "rubocop" unless File.exist?("bin/rubocop")
 
 say_git "Replace .rubocop.yml"
 template ".rubocop.yml", context: binding, force: true


### PR DESCRIPTION
Starting with Rails 7.2, `rails new` generates a custom `bin/rubocop` binstub that contains some optimizations. If we generate a standard binstub using `bundle binstub rubocop`, this will inadvertently clobber those optimizations.

Fix by generating the binstub only when it doesn't already exist.