### PR TITLE
Remove Action Mailer config fix; no longer needed in Rails 7.2+

### DIFF
--- a/lib/nextgen/generators/action_mailer.rb
+++ b/lib/nextgen/generators/action_mailer.rb
@@ -7,22 +7,3 @@ if minitest?
 elsif rspec?
   empty_directory_with_keep_file "spec/mailers"
 end
-
-say_git "Ensure absolute URLs can be used in all environments"
-insert_into_file "config/environments/development.rb", <<-RUBY, after: "raise_delivery_errors = false\n"
-  config.action_mailer.default_url_options = {host: "localhost:3000"}
-  config.action_mailer.asset_host = "http://localhost:3000"
-RUBY
-
-insert_into_file "config/environments/test.rb", <<-RUBY, after: "config.action_mailer.delivery_method = :test\n"
-  config.action_mailer.default_url_options = {host: "localhost:3000"}
-  config.action_mailer.asset_host = "http://localhost:3000"
-RUBY
-
-insert_into_file "config/environments/production.rb", <<-RUBY, after: /config\.action_mailer\.raise_deliv.*\n/
-  config.action_mailer.default_url_options = {
-    host: ENV.fetch("RAILS_HOSTNAME", "app.example.com"),
-    protocol: "https"
-  }
-  config.action_mailer.asset_host = "https://\#{ENV.fetch("RAILS_HOSTNAME", "app.example.com")}"
-RUBY

--- a/lib/nextgen/generators/rack_canonical_host.rb
+++ b/lib/nextgen/generators/rack_canonical_host.rb
@@ -8,3 +8,7 @@ document_deploy_var "RAILS_HOSTNAME", "Redirect all requests to the specified ca
 insert_into_file "config.ru",
   %(use Rack::CanonicalHost, ENV.fetch("RAILS_HOSTNAME", nil) if ENV["RAILS_HOSTNAME"].present?\n),
   before: /^run Rails.application/
+
+gsub_file "config/environments/production.rb",
+  /\bhost: "example\.com"/,
+  'host: ENV.fetch("RAILS_HOSTNAME", "example.com")'


### PR DESCRIPTION
Prior to Rails 7.2, the default Action Mailer config lacked values for `default_url_options`, which led to various problems. Nextgen has historically applied its own config to work around this issue.

However, starting with Rails 7.2, this has been fixed, so our workaround is no longer needed.