### PR TITLE
Explicitly set config path in RuboCop task

### DIFF
--- a/template/lib/tasks/rubocop.rake
+++ b/template/lib/tasks/rubocop.rake
@@ -3,4 +3,6 @@
 return unless Gem.loaded_specs.key?("rubocop")
 
 require "rubocop/rake_task"
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.options.push "-c", ".rubocop.yml"
+end


### PR DESCRIPTION
When a specific config path is not passed to RuboCop, it will search for configs in parent directories, which can have unexpected side-effects. E.g. when testing nextgen, I would often run into this when generating an app in a subdirectory of nextgen, which has its own RuboCop config. The config in the generated app and in the parent directory would be merged, leading to failures.

This PR updates the `rubocop` rake task to explicitly set the config path, fixing this problem. It also mirrors a similar fix provided by Rails itself in the `bin/rubocop` binstub: https://github.com/rails/rails/blob/e1d58cfd05ae1cc0bfc1006b7ce973a7730831df/railties/lib/rails/generators/rails/app/templates/bin/rubocop.tt#L4-L5