### PR TITLE
Update Puma worker count in documentation

### DIFF
--- a/template/DEPLOYMENT.md
+++ b/template/DEPLOYMENT.md
@@ -8,4 +8,4 @@ These environment variables affect how the app functions when deployed in produc
 - `RAILS_ENV` **REQUIRED** - "production"
 - `RAILS_MAX_THREADS` - Number of threads per Puma process (default: 3)
 - `SECRET_KEY_BASE` **REQUIRED** - Unique, secret key used to encrypt and sign cookies and other sensitive data
-- `WEB_CONCURRENCY` - Number of Puma processes (default: number of CPUs)
+- `WEB_CONCURRENCY` - Number of Puma processes (default: 1)


### PR DESCRIPTION
Since Rails 7.1.4, the default worker count for Puma is now 1. Update the generated deployment documentation to reflect this.