### PR TITLE
Remove sprockets JS tag when Vite is installed

### DIFF
--- a/lib/nextgen/generators/vite.rb
+++ b/lib/nextgen/generators/vite.rb
@@ -117,7 +117,8 @@ say_git "Remove sprockets"
 remove_file "config/initializers/assets.rb"
 comment_lines "config/environments/development.rb", /^\s*config\.assets\./
 comment_lines "config/environments/production.rb", /^\s*config\.assets\./
-gsub_file "app/views/layouts/application.html.erb", /^.*<%= stylesheet_link_tag.*$/, ""
+gsub_file "app/views/layouts/application.html.erb", /^.*<%= javascript_include_tag.*\n/, ""
+gsub_file "app/views/layouts/application.html.erb", /^.*<%= stylesheet_link_tag.*\n/, ""
 remove_gem "sprockets-rails"
 
 if File.exist?(".github/workflows/ci.yml")


### PR DESCRIPTION
Before, generating a Vite-enabled app with nextgen would leave this in `application.html.erb`:

```erb
<%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
```

Since a Vite app doesn't use sprockets, this tag is not needed.

This PR updates the "remove sprockets" step of the Vite installation to remove the tag.

Originally reported in #107.