### PR TITLE
Run assorted e2e test scenarios in separate CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["current", "edge"]
-        frontend: ["default", "vite"]
-        test-framework: ["minitest", "rspec"]
+        include:
+          - version: current
+            frontend: default
+            test-framework: minitest
+          - version: current
+            frontend: default
+            test-framework: rspec
+          - version: current
+            frontend: vite
+            test-framework: minitest
+          - version: current
+            frontend: vite
+            test-framework: rspec
+          - version: edge
+            frontend: default
+            test-framework: minitest
     needs: [rubocop, test]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake test
   integration-test:
-    name: "Test / E2E / Rails ${{ matrix.version }} / ${{ matrix.frontend }} / ${{ matrix.test-framework }}"
+    name: "Test / E2E / Rails ${{ matrix.version }} / ${{ matrix.frontend }} frontend / ${{ matrix.test-framework }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -66,6 +66,7 @@ jobs:
           NEXTGEN_TEST_FRAMEWORK: ${{ matrix.test-framework }}
         run: bundle exec rake test:e2e
   test-all:
+    name: "Test / All"
     runs-on: ubuntu-latest
     needs: [test, integration-test]
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,14 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake test
-  integration_test:
-    name: "Test / E2E"
+  integration-test:
+    name: "Test / E2E / Rails ${{ matrix.version }} / ${{ matrix.frontend }} / ${{ matrix.test-framework }}"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ["current", "edge"]
+        frontend: ["default", "vite"]
+        test-framework: ["minitest", "rspec"]
     needs: [rubocop, test]
     steps:
       - uses: actions/checkout@v4
@@ -41,4 +46,20 @@ jobs:
       - run: git config --global user.name 'github-actions[bot]'
       - run: git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       - run: gem install --no-document railties --version "~> 7.2.0"
-      - run: bundle exec rake test:e2e
+      - name: rake test:e2e
+        env:
+          NEXTGEN_VERSION: ${{ matrix.version }}
+          NEXTGEN_FRONTEND: ${{ matrix.frontend }}
+          NEXTGEN_TEST_FRAMEWORK: ${{ matrix.test-framework }}
+        run: bundle exec rake test:e2e
+  test-all:
+    runs-on: ubuntu-latest
+    needs: [test, integration-test]
+    if: always()
+    steps:
+      - name: All tests ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/test/e2e/nextgen_e2e_test.rb
+++ b/test/e2e/nextgen_e2e_test.rb
@@ -6,16 +6,29 @@ require "open3"
 require "securerandom"
 
 class NextgenE2ETest < Minitest::Test
+  VERSION_KEYSTROKES = {
+    current: "",
+    edge: "\e[B"
+  }.freeze
+
+  FRONTEND_KEYSTROKES = {
+    default: "",
+    vite: "\e[B\e[B"
+  }.freeze
+
+  TEST_FRAMEWORK_KEYSTROKES = {
+    minitest: "",
+    rspec: "\e[B"
+  }.freeze
+
   def test_nextgen_generates_rails_app
-    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\n\n\n\n\n\n\n\u0001\n\n")
-  end
+    version_keys = VERSION_KEYSTROKES.fetch((ENV["NEXTGEN_VERSION"] || "current").to_sym)
+    frontend_keys = FRONTEND_KEYSTROKES.fetch((ENV["NEXTGEN_FRONTEND"] || "default").to_sym)
+    test_framework_keys = TEST_FRAMEWORK_KEYSTROKES.fetch((ENV["NEXTGEN_TEST_FRAMEWORK"] || "minitest").to_sym)
 
-  def test_nextgen_generates_vite_rails_app
-    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\e[B\e[B\n\n\n\n\n\u0001\n\n")
-  end
+    stdin_data = "\n" + version_keys + "\n\n\n" + frontend_keys + "\n\n\n\n\n" + test_framework_keys + "\n\n\u0001\n\n"
 
-  def test_nextgen_generates_rspec_rails_app
-    assert_bundle_exec_nextgen_create(stdin_data: "\n\n\n\n\n\n\n\n\n\e[B\n\n\u0001\n\n")
+    assert_bundle_exec_nextgen_create(stdin_data:)
   end
 
   private


### PR DESCRIPTION
Instead of manually writing different test cases for different combinations of answers (Vite, RSpec, etc.), parameterize those options via environment variables. This lets us run various scenarios via CI in parallel across a matrix of jobs.

This gives us better test coverage and should run faster due to parallel execution.