### PR TITLE
Mute deprecations so stylelint works with overcommit

### DIFF
--- a/template/.overcommit.yml.tt
+++ b/template/.overcommit.yml.tt
@@ -68,6 +68,8 @@ PreCommit:
     enabled: true
     required_executable: npx
     command: ["npx", "--no-install", "stylelint"]
+    env:
+      NODE_OPTIONS: --no-deprecation
     include:
       - app/assets/**/*.css
       - app/components/**/*.css


### PR DESCRIPTION
Stylelint recently introduced a deprecation that causes warnings to be printed when using the `stylelint-declaration-strict-value` package.

```
(node:86769) [stylelint:005] DeprecationWarning: `context.fix` is being deprecated.
Please pass a `fix` callback to the `report` utility of "scale-unlimited/declaration-strict-value" instead.
```

This breaks overcommit, which tries to parse stderr from the stylelint process to determine what files have lint issues.

To work around this problem, pass `NODE_OPTIONS=--no-deprecation` when running stylelint via overcommit so that the warnings are not printed.