### PR TITLE
Refactor `RailsOptions` to load supported values from YAML config

### DIFF
--- a/config/rails_versions.yml
+++ b/config/rails_versions.yml
@@ -1,0 +1,28 @@
+current: &current
+  args: []
+  label: "%%CURRENT_VERSION%%"
+  asset_pipelines:
+    sprockets: Sprockets (default)
+    propshaft: Propshaft
+  databases:
+    sqlite3: SQLite3 (default)
+    postgresql: PostgreSQL (recommended)
+    mysql: MySQL
+    trilogy: Trilogy
+    oracle: Oracle
+    sqlserver: SQLServer
+    jdbcmysql: JDBCMySQL
+    jdbcsqlite3: JDBCSQLite3
+    jdbcpostgresql: JDBCPostgreSQL
+    jdbc: JDBC
+  default_features:
+    brakeman: Brakeman
+    ci: GitHub Actions CI
+    rubocop: RuboCop
+  optional_features:
+    devcontainer: devcontainer files
+
+edge:
+  <<: *current
+  args: ["--edge"]
+  label: "edge (7-2-stable)"

--- a/lib/nextgen/rails_command.rb
+++ b/lib/nextgen/rails_command.rb
@@ -1,22 +1,8 @@
 # frozen_string_literal: true
 
-require "rails/version"
-
 module Nextgen
-  module Rails
+  module RailsCommand
     class << self
-      def version
-        ::Rails.version
-      end
-
-      def edge_branch
-        if version.match?(/[a-z]/i)
-          "main"
-        else
-          version[/^\d+\.\d+/].tr(".", "-") + "-stable"
-        end
-      end
-
       def run(*args, raise_on_error: true)
         command = "rails", *args
         say_status :run, *command.join(" ")

--- a/lib/nextgen/rails_version.rb
+++ b/lib/nextgen/rails_version.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails/version"
+require "yaml"
+
+module Nextgen
+  RailsVersion = Struct.new(
+    :args,
+    :label,
+    :asset_pipelines,
+    :databases,
+    :default_features,
+    :optional_features,
+    keyword_init: true
+  )
+
+  class << RailsVersion
+    def current
+      from_yaml(:current) do |version|
+        version.label.sub!("%%CURRENT_VERSION%%") { ::Rails.version }
+      end
+    end
+
+    def edge
+      from_yaml(:edge)
+    end
+
+    private
+
+    def from_yaml(key)
+      @yaml ||= begin
+        yaml_path = File.expand_path("../../config/rails_versions.yml", __dir__)
+        YAML.load_file(yaml_path, aliases: true, symbolize_names: true)
+      end
+      new(**@yaml.fetch(key)).tap do |version|
+        yield(version) if block_given?
+      end.freeze
+    end
+  end
+end

--- a/test/nextgen/rails_options_test.rb
+++ b/test/nextgen/rails_options_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class Nextgen::RailsOptionsTest < Minitest::Test
   def test_api_mode_can_be_specified
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.api!
 
     assert(opts.api?)
@@ -12,7 +12,7 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_api_mode_prohibits_frontend_options
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.api!
 
     assert_prohibited { opts.css = "sass" }
@@ -20,14 +20,14 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_css_prohibits_api_mode
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.css = "sass"
 
     assert_prohibited { opts.api! }
   end
 
   def test_javascript_prohibits_api_mode
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.javascript = "esbuild"
 
     assert_prohibited { opts.api! }
@@ -35,13 +35,13 @@ class Nextgen::RailsOptionsTest < Minitest::Test
 
   def test_node_requirement_depends_on_css_option
     %w[bootstrap bulma postcss sass].each do |css|
-      opts = Nextgen::RailsOptions.new
+      opts = build_rails_options
       opts.css = css
 
       assert(opts.requires_node?)
     end
 
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.css = "tailwind"
 
     refute(opts.requires_node?)
@@ -49,34 +49,34 @@ class Nextgen::RailsOptionsTest < Minitest::Test
 
   def test_node_requirement_depends_on_javascript_option
     %w[webpack esbuild rollup].each do |js|
-      opts = Nextgen::RailsOptions.new
+      opts = build_rails_options
       opts.javascript = js
 
       assert(opts.requires_node?)
     end
 
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.javascript = "importmap"
 
     refute(opts.requires_node?)
   end
 
   def test_css_can_be_specified
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.css = "bulma"
 
     assert_equal(["--css=bulma"], opts.to_args)
   end
 
   def test_javascript_can_be_specified
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.javascript = "esbuild"
 
     assert_equal(["--javascript=esbuild"], opts.to_args)
   end
 
   def test_javascript_can_be_skipped_by_assigning_nil
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.javascript = nil
 
     assert(opts.skip_javascript?)
@@ -84,23 +84,23 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_asset_pipeline_can_be_specified
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
 
-    opts.asset_pipeline = "sprockets"
+    opts.asset_pipeline = :sprockets
     assert_equal(["--asset-pipeline=sprockets"], opts.to_args)
 
-    opts.asset_pipeline = "propshaft"
+    opts.asset_pipeline = :propshaft
     assert_equal(["--asset-pipeline=propshaft"], opts.to_args)
   end
 
   def test_invalid_asset_pipeline_raises
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
 
-    assert_raises(ArgumentError) { opts.asset_pipeline = "something" }
+    assert_raises(ArgumentError) { opts.asset_pipeline = :something }
   end
 
   def test_assigning_nil_disables_asset_pipeline_allows_and_prohibits_other_frontend_options
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.asset_pipeline = nil
 
     assert_prohibited { opts.css = "sass" }
@@ -108,7 +108,7 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_vite_disables_asset_pipeline_and_uses_esbuild_under_the_hood
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
 
     refute_predicate opts, :vite?
 
@@ -118,7 +118,7 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_assigning_nil_database_disables_active_record
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.database = nil
 
     assert(opts.skip_active_record?)
@@ -126,31 +126,31 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_database_can_be_specified
-    opts = Nextgen::RailsOptions.new
-    opts.database = "postgresql"
+    opts = build_rails_options
+    opts.database = :postgresql
 
     assert_equal(["--database=postgresql"], opts.to_args)
   end
 
   def test_invalid_database_raises
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
 
-    assert_raises(ArgumentError) { opts.database = "rds" }
+    assert_raises(ArgumentError) { opts.database = :rds }
   end
 
   def test_optional_frameworks_can_be_skipped
-    opts = Nextgen::RailsOptions.new
-    opts.skip_optional_feature!("action_mailer")
-    opts.skip_optional_feature!("action_mailbox")
-    opts.skip_optional_feature!("action_text")
-    opts.skip_optional_feature!("active_job")
-    opts.skip_optional_feature!("active_storage")
-    opts.skip_optional_feature!("action_cable")
-    opts.skip_optional_feature!("brakeman")
-    opts.skip_optional_feature!("ci")
-    opts.skip_optional_feature!("hotwire")
-    opts.skip_optional_feature!("jbuilder")
-    opts.skip_optional_feature!("rubocop")
+    opts = build_rails_options
+    opts.skip_default_feature!(:action_mailer)
+    opts.skip_default_feature!(:action_mailbox)
+    opts.skip_default_feature!(:action_text)
+    opts.skip_default_feature!(:active_job)
+    opts.skip_default_feature!(:active_storage)
+    opts.skip_default_feature!(:action_cable)
+    opts.skip_default_feature!(:brakeman)
+    opts.skip_default_feature!(:ci)
+    opts.skip_default_feature!(:hotwire)
+    opts.skip_default_feature!(:jbuilder)
+    opts.skip_default_feature!(:rubocop)
 
     assert_equal(
       %w[
@@ -171,41 +171,41 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_invalid_optional_frameworks_raises
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
 
-    assert_raises(ArgumentError) { opts.skip_optional_feature!("action_blah") }
+    assert_raises(ArgumentError) { opts.skip_default_feature!(:action_blah) }
   end
 
   def test_test_framework_can_be_set_to_minitest
-    opts = Nextgen::RailsOptions.new
-    opts.test_framework = "minitest"
+    opts = build_rails_options
+    opts.test_framework = :minitest
 
     assert_empty(opts.to_args)
   end
 
   def test_test_framework_can_be_set_to_rspec
-    opts = Nextgen::RailsOptions.new
-    opts.test_framework = "rspec"
+    opts = build_rails_options
+    opts.test_framework = :rspec
 
     assert(opts.rspec?)
     assert_equal(["--skip-test"], opts.to_args)
   end
 
   def test_test_framework_can_be_set_to_nil
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.test_framework = nil
 
     assert_equal(["--skip-test"], opts.to_args)
   end
 
   def test_invalid_test_framework_raises
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
 
-    assert_raises(ArgumentError) { opts.test_framework = "mocha" }
+    assert_raises(ArgumentError) { opts.test_framework = :mocha }
   end
 
   def test_system_test_can_be_skipped
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
     opts.skip_system_test!
 
     assert(opts.skip_system_test?)
@@ -213,14 +213,14 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   end
 
   def test_devcontainer_is_opt_in
-    opts = Nextgen::RailsOptions.new
-    opts.devcontainer!
+    opts = build_rails_options
+    opts.enable_optional_feature!(:devcontainer)
 
     assert_equal(["--devcontainer"], opts.to_args)
   end
 
   def test_defaults
-    opts = Nextgen::RailsOptions.new
+    opts = build_rails_options
 
     refute(opts.api?)
     refute(opts.requires_node?)
@@ -233,7 +233,28 @@ class Nextgen::RailsOptionsTest < Minitest::Test
     assert_empty(opts.to_args)
   end
 
+  def test_delegates_to_rails_version
+    current_version = Nextgen::RailsVersion.current
+    opts = Nextgen::RailsOptions.new(version: current_version)
+
+    assert_equal current_version.label, opts.version_label
+    assert_equal current_version.asset_pipelines, opts.asset_pipelines
+    assert_equal current_version.databases, opts.databases
+    assert_equal current_version.default_features, opts.default_features
+    assert_equal current_version.optional_features, opts.optional_features
+  end
+
+  def test_using_edge_version_adds_edge_arg
+    opts = Nextgen::RailsOptions.new(version: Nextgen::RailsVersion.edge)
+
+    assert_includes opts.to_args, "--edge"
+  end
+
   private
+
+  def build_rails_options
+    Nextgen::RailsOptions.new(version: Nextgen::RailsVersion.current)
+  end
 
   def assert_prohibited(&)
     error = assert_raises(ArgumentError, &)

--- a/test/nextgen/rails_version_test.rb
+++ b/test/nextgen/rails_version_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Nextgen
+  class RailsVersionTest < Minitest::Test
+    def test_current_version_is_loaded_from_rails_versions_yaml
+      current = RailsVersion.current
+
+      assert_empty current.args
+      assert_equal Rails.version, current.label
+      assert_instance_of Hash, current.asset_pipelines
+      assert_instance_of Hash, current.databases
+      assert_instance_of Hash, current.default_features
+      assert_equal({devcontainer: "devcontainer files"}, current.optional_features)
+    end
+
+    def test_edge_version_is_same_as_current_except_label_and_args
+      current = RailsVersion.current
+      edge = RailsVersion.edge
+
+      assert_equal "edge (7-2-stable)", edge.label
+      assert_equal ["--edge"], edge.args
+
+      %i[asset_pipelines databases default_features optional_features].each do |attr|
+        assert_equal current.public_send(attr), edge.public_send(attr)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The options supported by `rails new` change for each version of Rails. These include the list of databases, supported asset pipelines, features that can be enabled or skipped, and so on.

To make nextgen more flexible and adaptable to these changes over time, I've refactored `RailsOptions` and related code so that these values are no longer hard-coded, but instead loaded from a `rails_versions.yml` file.

Now, when a new version of Rails comes out, we can modify this config file to easily add support for new `rails new` options.

More significantly, this allows a single version of nextgen to support *multiple* versions of Rails, by providing different sets of config in `rails_versions.yml`.

Right now, nextgen supports `current` and `edge`, but a future PR will leverage this foundation to add support for `main` (Rails 8).