### PR TITLE
Remove sprockets option for Rails 8 apps

### DIFF
--- a/config/rails_versions.yml
+++ b/config/rails_versions.yml
@@ -32,7 +32,6 @@ main:
   label: "main (%%MAIN_VERSION%%)"
   asset_pipelines:
     propshaft: Propshaft (default)
-    sprockets: Sprockets
   databases:
     sqlite3: SQLite3 (default)
     postgresql: PostgreSQL (recommended)

--- a/lib/nextgen/generators/vite.rb
+++ b/lib/nextgen/generators/vite.rb
@@ -113,13 +113,12 @@ RUBY
 say_git "Remove jsbundling-rails"
 remove_gem "jsbundling-rails"
 
-say_git "Remove sprockets"
+say_git "Remove asset pipeline"
 remove_file "config/initializers/assets.rb"
 comment_lines "config/environments/development.rb", /^\s*config\.assets\./
 comment_lines "config/environments/production.rb", /^\s*config\.assets\./
 gsub_file "app/views/layouts/application.html.erb", /^.*<%= javascript_include_tag.*\n/, ""
 gsub_file "app/views/layouts/application.html.erb", /^.*<%= stylesheet_link_tag.*\n/, ""
-remove_gem "sprockets-rails"
 
 if File.exist?(".github/workflows/ci.yml")
   say_git "Add Node steps to CI workflow"

--- a/lib/nextgen/rails_options.rb
+++ b/lib/nextgen/rails_options.rb
@@ -198,7 +198,7 @@ module Nextgen
         args << "--skip-javascript" if skip_javascript?
         args << "--skip-test" if skip_test?
         args << "--skip-system-test" if skip_system_test?
-        args << "--asset-pipeline=#{asset_pipeline}" if asset_pipeline
+        args << "--asset-pipeline=#{asset_pipeline}" if asset_pipeline && asset_pipeline != asset_pipelines.keys.first
         args << "--database=#{database}" if database
         args << "--css=#{css}" if css
         args << "--javascript=#{javascript}" if javascript

--- a/test/nextgen/rails_options_test.rb
+++ b/test/nextgen/rails_options_test.rb
@@ -86,9 +86,6 @@ class Nextgen::RailsOptionsTest < Minitest::Test
   def test_asset_pipeline_can_be_specified
     opts = build_rails_options
 
-    opts.asset_pipeline = :sprockets
-    assert_equal(["--asset-pipeline=sprockets"], opts.to_args)
-
     opts.asset_pipeline = :propshaft
     assert_equal(["--asset-pipeline=propshaft"], opts.to_args)
   end
@@ -248,6 +245,16 @@ class Nextgen::RailsOptionsTest < Minitest::Test
     opts = Nextgen::RailsOptions.new(version: Nextgen::RailsVersion.edge)
 
     assert_includes opts.to_args, "--edge"
+  end
+
+  def test_does_not_use_asset_pipeline_arg_when_propshaft_is_the_only_supported_option
+    version = Nextgen::RailsVersion.current.dup
+    version.asset_pipelines = {propshaft: "Propshaft (default)"}
+    opts = Nextgen::RailsOptions.new(version:)
+
+    opts.asset_pipeline = :propshaft
+
+    refute_includes opts.to_args, "--asset-pipeline=propshaft"
   end
 
   private


### PR DESCRIPTION
Rails 8 has completely removed sprockets, and no longer supports `rails new --asset-pipeline=sprockets`. This PR updates nextgen to remove the sprockets option when Rails 8 is selected. Now only propshaft and vite are presented.

```
How will you manage frontend assets? 
‣ Propshaft (default)
  Vite
```