### PR TITLE
Properly identify Rails main version as 8.0.0.beta1

### DIFF
--- a/lib/nextgen/rails_version.rb
+++ b/lib/nextgen/rails_version.rb
@@ -46,9 +46,7 @@ module Nextgen
 
     def main_version
       @main_version ||= begin
-        version_rb = URI.open("https://raw.githubusercontent.com/rails/rails/main/version.rb").read
-        version_pattern = /\s+MAJOR\s+= (\d+)\n\s*MINOR\s+= (\d+)\n\s*TINY\s+= (\d+)\n\s*PRE\s+= "(\w+)"/
-        version_rb.match(version_pattern)&.captures&.join(".")
+        URI.open("https://raw.githubusercontent.com/rails/rails/main/RAILS_VERSION").read.strip
       rescue OpenURI::HTTPError
         "unknown"
       end

--- a/test/nextgen/rails_version_test.rb
+++ b/test/nextgen/rails_version_test.rb
@@ -28,15 +28,8 @@ module Nextgen
     end
 
     def test_main_version_parses_version_number_from_rails_github_repo
-      stub_request(:get, "https://raw.githubusercontent.com/rails/rails/main/version.rb").to_return(body: <<~RUBY)
-        module Rails
-          module VERSION
-            MAJOR = 8
-            MINOR = 0
-            TINY  = 0
-            PRE   = "rc1"
-          end
-        end
+      stub_request(:get, "https://raw.githubusercontent.com/rails/rails/main/RAILS_VERSION").to_return(body: <<~RUBY)
+        8.0.0.rc1
       RUBY
 
       main = RailsVersion.main


### PR DESCRIPTION
Recent changes to the Rails GitHub repo caused nextgen to identify the main branch version as "unknown". Fix how the version is determined so that it is more reliable and doesn't rely on a fragile regex.

Now the main version is correctly identified as "8.0.0.beta1":

```
What version of Rails will you use? (Press ↑/↓ arrow to move and Enter to select)
‣ 7.2.1
  edge (7-2-stable)
  main (8.0.0.beta1)
```