### PR TITLE
Optimize system test performance with `--disable-gpu`

### DIFF
--- a/template/spec/support/system.rb
+++ b/template/spec/support/system.rb
@@ -8,6 +8,9 @@ RSpec.configure do |config|
         # Allows running in Docker
         options.add_argument("--disable-dev-shm-usage")
         options.add_argument("--no-sandbox")
+
+        # Fixes slowdowns on macOS
+        options.add_argument("--disable-gpu")
       end
   end
 end

--- a/template/test/application_system_test_case.rb
+++ b/template/test/application_system_test_case.rb
@@ -9,5 +9,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       # Allows running in Docker
       options.add_argument("--disable-dev-shm-usage")
       options.add_argument("--no-sandbox")
+
+      # Fixes slowdowns on macOS
+      options.add_argument("--disable-gpu")
     end
 end


### PR DESCRIPTION
In my experience, `--disable-gpu` makes headless Chrome tests run considerably faster on my macOS Apple Silicon (M3) machine.