### PR TITLE
Commit Gemfile.lock after adding Gemfile `ruby` declaration

### DIFF
--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -49,6 +49,7 @@ if missing_ruby_decl && File.exist?(".ruby-version") && File.read(".ruby-version
                 'ruby Pathname.new(__dir__).join(".ruby-version").read.strip'
               end
   gsub_file "Gemfile", /^source .*$/, '\0' + "\n#{ruby_decl}"
+  bundle_command! "lock"
 end
 
 if File.exist?("app/views/layouts/application.html.erb")


### PR DESCRIPTION
Rails no longer includes a `ruby` declaration in the generated Gemfile. When nextgen adds it, a side-effect is that the Gemfile.lock will change the next time `bundle install` is run. This means that after generating a project, when you run `bin/setup` for the first time, it may cause the Gemfile.lock to change.

Fix by proactively running `bundle lock` and committing the result, so that the Gemfile.lock in the generated project is guaranteed to be up to date.