### PR TITLE
Fix `Benchmark.ms` deprecation warning on Rails 8

### DIFF
--- a/template/test/vite_helper.rb
+++ b/template/test/vite_helper.rb
@@ -3,5 +3,6 @@
 return if ViteRuby.config.auto_build
 
 # Compile assets once at the start of testing
-millis = Benchmark.ms { ViteRuby.commands.build }
-puts format("Built Vite assets (%.1fms)", millis)
+require "benchmark"
+seconds = Benchmark.realtime { ViteRuby.commands.build }
+puts format("Built Vite assets (%.1fms)", seconds * 1_000)


### PR DESCRIPTION
This fixes the following deprecation warning:

> `Benchmark.ms` is deprecated and will be removed in Rails 8.1 without replacement.