### PR TITLE
Copy `.ruby-version` so that `bundle install` works in Docker

### DIFF
--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -49,6 +49,7 @@ if missing_ruby_decl && File.exist?(".ruby-version") && File.read(".ruby-version
                 'ruby Pathname.new(__dir__).join(".ruby-version").read.strip'
               end
   gsub_file "Gemfile", /^source .*$/, '\0' + "\n#{ruby_decl}"
+  gsub_file "Dockerfile", "COPY Gemfile", "COPY .ruby-version Gemfile" if File.exist?("Dockerfile")
   bundle_command! "lock"
 end
 


### PR DESCRIPTION
Because we have a `ruby file: ".ruby-version"` declaration in our `Gemfile`, that means that the `.ruby-version` file must be present to be able to run `bundle install`.