### PR TITLE
Fix bug where `rails new` used 8.0.0.rc1 instead of the intended 7.2.1

### DIFF
--- a/lib/nextgen/rails_command.rb
+++ b/lib/nextgen/rails_command.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require "rails/version"
+
 module Nextgen
   module RailsCommand
     class << self
       def run(*args, raise_on_error: true)
-        command = "rails", *args
+        command = "rails", "_#{::Rails.version}_", *args
         say_status :run, *command.join(" ")
         with_original_bundler_env do
           system(*command, exception: raise_on_error)


### PR DESCRIPTION
Nextgen currently targets Rails 7.2. However, if someone has a prerelease version of the Rails gems installed, e.g. 8.0.0.rc1, then the `rails new` command issued by Nextgen will use the 8.0.0.rc1 version. This is confusing, because picking "7.2.1" from the interactive menu in Nextgen will end up creating an 8.0 app.

Fix by using the RubyGems underscored version argument when calling the `rails new` command:

```
rails _7.2.1_ new ...
```

This tells RubyGems the explicit version of the `rails` binary that we want to use.