### PR TITLE
Replace deprecated stylelint plugin with built-in alternative

### DIFF
--- a/lib/nextgen/generators/stylelint.rb
+++ b/lib/nextgen/generators/stylelint.rb
@@ -4,7 +4,6 @@ say_git "Install stylelint"
 add_js_packages(
   "stylelint",
   "stylelint-config-standard",
-  "stylelint-declaration-strict-value",
   "stylelint-prettier",
   "prettier",
   "npm-run-all",

--- a/template/.overcommit.yml.tt
+++ b/template/.overcommit.yml.tt
@@ -68,8 +68,6 @@ PreCommit:
     enabled: true
     required_executable: npx
     command: ["npx", "--no-install", "stylelint"]
-    env:
-      NODE_OPTIONS: --no-deprecation
     include:
       - app/assets/**/*.css
       - app/components/**/*.css

--- a/template/.stylelintrc.js
+++ b/template/.stylelintrc.js
@@ -1,7 +1,4 @@
-import strictValuePlugin from "stylelint-declaration-strict-value";
-
 export default {
-  plugins: [strictValuePlugin],
   extends: ["stylelint-config-standard", "stylelint-prettier/recommended"],
   rules: {
     "color-hex-length": null,
@@ -18,17 +15,19 @@ export default {
         ignoreProperties: ["font-named-instance"],
       },
     ],
-    "scale-unlimited/declaration-strict-value": [
-      "/color/",
+    "declaration-property-value-allowed-list": [
       {
-        disableFix: true,
-        ignoreValues: [
+        "/color/": [
+          /^var\(--/,
           "currentcolor",
           "inherit",
           "initial",
           "transparent",
           "unset",
         ],
+      },
+      {
+        message: "Found hard-coded color value; expected var(--...)",
       },
     ],
     "selector-class-pattern": [


### PR DESCRIPTION
The `stylelint-declaration-strict-value` plugin has been emitting deprecation warnings with the latest version of stylelint for a couple months now, and doesn't seem to be proactively maintained.

Stylelint actually has a built-in rule [declaration-property-value-allowed-list](https://stylelint.io/user-guide/rules/declaration-property-value-allowed-list/) that is similar and does what we need, so let's use that instead.