### PR TITLE
Switch to `ubuntu-latest` GitHub Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   rubocop:
     name: "Rubocop"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -17,7 +17,7 @@ jobs:
       - run: bundle exec rubocop
   test:
     name: "Test / Ruby ${{ matrix.ruby }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby: ["3.2", "3.3", "3.4", "head"]
@@ -30,7 +30,7 @@ jobs:
       - run: bundle exec rake test
   integration-test:
     name: "Test / E2E / Rails ${{ matrix.version }} / ${{ matrix.frontend }} frontend / ${{ matrix.test-framework }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -79,7 +79,7 @@ jobs:
         run: bundle exec rake test:e2e
   test-all:
     name: "Test / All"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [test, integration-test]
     if: always()
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
         env:

--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -81,8 +81,3 @@ if (time_zone = read_system_time_zone_name)
   uncomment_lines "config/application.rb", /config\.time_zone/
   gsub_file "config/application.rb", /(config\.time_zone = ).*$/, "\\1#{time_zone.inspect}"
 end
-
-if File.exist?(".github/workflows/ci.yml")
-  say_git "Opt into ubuntu-24.04 GitHub Actions runner"
-  gsub_file ".github/workflows/ci.yml", /\bubuntu-latest\b/, "ubuntu-24.04"
-end

--- a/lib/nextgen/generators/bundler_audit.rb
+++ b/lib/nextgen/generators/bundler_audit.rb
@@ -7,7 +7,7 @@ if File.exist?(".github/workflows/ci.yml")
   say_git "Add bundle-audit job to CI workflow"
   inject_into_file ".github/workflows/ci.yml", <<-YAML, after: /^jobs:\n/
   scan_gems:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/lib/nextgen/generators/erb_lint.rb
+++ b/lib/nextgen/generators/erb_lint.rb
@@ -13,7 +13,7 @@ if File.exist?(".github/workflows/ci.yml")
   say_git "Add erb_lint job to CI workflow"
   inject_into_file ".github/workflows/ci.yml", <<-YAML, after: /^jobs:\n/
   erb_lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/lib/nextgen/generators/eslint.rb
+++ b/lib/nextgen/generators/eslint.rb
@@ -29,7 +29,7 @@ if File.exist?(".github/workflows/ci.yml")
   node_spec = File.exist?(".node-version") ? 'node-version-file: ".node-version"' : 'node-version: "lts/*"'
   inject_into_file ".github/workflows/ci.yml", <<-YAML, after: /^jobs:\n/
   eslint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/lib/nextgen/generators/rspec_github_actions.rb
+++ b/lib/nextgen/generators/rspec_github_actions.rb
@@ -4,7 +4,7 @@ return unless File.exist?(".github/workflows/ci.yml")
 
 erb = <<~YAML
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     <%- if gems.include?("pg") -%>
     services:

--- a/lib/nextgen/generators/stylelint.rb
+++ b/lib/nextgen/generators/stylelint.rb
@@ -26,7 +26,7 @@ if File.exist?(".github/workflows/ci.yml")
   node_spec = File.exist?(".node-version") ? 'node-version-file: ".node-version"' : 'node-version: "lts/*"'
   inject_into_file ".github/workflows/ci.yml", <<-YAML, after: /^jobs:\n/
   stylelint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
As of January 17, 2025, `ubuntu-latest` has fully rolled out 24.04, so we no longer have to pin to the `ubuntu-24.04` runner. This effectively reverts #129.