### PR TITLE
Generate rubocop.yml compatible with new rubocop plugin system

### DIFF
--- a/lib/nextgen/generators/rubocop.rb
+++ b/lib/nextgen/generators/rubocop.rb
@@ -4,13 +4,17 @@ say_git "Install rubocop gems"
 remove_gem "rubocop-rails-omakase"
 gemfile = File.read("Gemfile")
 plugins = []
-plugins << "capybara" if gemfile.match?(/^\s*gem ['"]capybara['"]/)
-plugins << "factory_bot" if gemfile.match?(/^\s*gem ['"]factory_bot/)
+requires = []
+requires << "capybara" if gemfile.match?(/^\s*gem ['"]capybara['"]/)
+requires << "factory_bot" if gemfile.match?(/^\s*gem ['"]factory_bot/)
 plugins << "minitest" if minitest?
 plugins << "performance"
 plugins << "rails"
-install_gem("rubocop-rails", version: ">= 2.22.0", group: :development, require: false)
-install_gems(*plugins.map { "rubocop-#{_1}" }, "rubocop", group: :development, require: false)
+rubocop_gems = [
+  "rubocop",
+  *[*plugins, *requires].sort.map { "rubocop-#{_1}" }
+]
+install_gems(*rubocop_gems.reverse, group: :development, require: false)
 binstub "rubocop" unless File.exist?("bin/rubocop")
 
 say_git "Replace .rubocop.yml"

--- a/template/.rubocop.yml.tt
+++ b/template/.rubocop.yml.tt
@@ -1,5 +1,11 @@
-require:
+<% if plugins.any? -%>
+plugins:
+<% end -%>
 <%= plugins.map { "  - rubocop-#{_1}" }.join("\n") %>
+<% if requires.any? -%>
+require:
+<%= requires.map { "  - rubocop-#{_1}" }.join("\n") %>
+<% end -%>
 
 inherit_mode:
   merge:

--- a/test/integration/generators/rubocop_test.rb
+++ b/test/integration/generators/rubocop_test.rb
@@ -16,14 +16,14 @@ class Nextgen::Generators::RubocopTest < Nextgen::Generators::TestCase
     GEMFILE
   end
 
-  test "adds rubocop gems in development group, with version spec for rubocop-rails" do
+  test "adds rubocop gems in development group" do
     apply_generator
 
     assert_file "Gemfile", /#{Regexp.quote(<<~GEMFILE)}/
       group :development do
         gem "rubocop", require: false
         gem "rubocop-performance", require: false
-        gem "rubocop-rails", ">= 2.22.0", require: false
+        gem "rubocop-rails", require: false
       end
     GEMFILE
   end
@@ -32,7 +32,7 @@ class Nextgen::Generators::RubocopTest < Nextgen::Generators::TestCase
     apply_generator
 
     assert_file ".rubocop.yml", /#{Regexp.quote(<<~YML)}/
-      require:
+      plugins:
         - rubocop-performance
         - rubocop-rails
     YML


### PR DESCRIPTION
Some RuboCop gems are now packaged as "plugins". To be used properly, they need to be referenced in `.rubocop.yml` in a `plugins:` section, instead of `require:`.

This PR changes nextgen's generated `.rubocop.yml` to follow this new convention.