### PR TITLE
Adopt plugin-style loading for capybara and factory_bot rubocop gems

### DIFF
--- a/lib/nextgen/generators/rubocop.rb
+++ b/lib/nextgen/generators/rubocop.rb
@@ -4,15 +4,14 @@ say_git "Install rubocop gems"
 remove_gem "rubocop-rails-omakase"
 gemfile = File.read("Gemfile")
 plugins = []
-requires = []
-requires << "capybara" if gemfile.match?(/^\s*gem ['"]capybara['"]/)
-requires << "factory_bot" if gemfile.match?(/^\s*gem ['"]factory_bot/)
+plugins << "capybara" if gemfile.match?(/^\s*gem ['"]capybara['"]/)
+plugins << "factory_bot" if gemfile.match?(/^\s*gem ['"]factory_bot/)
 plugins << "minitest" if minitest?
 plugins << "performance"
 plugins << "rails"
 rubocop_gems = [
   "rubocop",
-  *[*plugins, *requires].sort.map { "rubocop-#{_1}" }
+  *plugins.sort.map { "rubocop-#{_1}" }
 ]
 install_gems(*rubocop_gems.reverse, group: :development, require: false)
 binstub "rubocop" unless File.exist?("bin/rubocop")

--- a/template/.rubocop.yml.tt
+++ b/template/.rubocop.yml.tt
@@ -2,10 +2,6 @@
 plugins:
 <% end -%>
 <%= plugins.map { "  - rubocop-#{_1}" }.join("\n") %>
-<% if requires.any? -%>
-require:
-<%= requires.map { "  - rubocop-#{_1}" }.join("\n") %>
-<% end -%>
 
 inherit_mode:
   merge:


### PR DESCRIPTION
RuboCop gems are being migrated to a new "plugin" format. This means projects that use these gems need to load them with `plugins:` instead of `require:` in order to avoid deprecation warnings.