### PR TITLE
[Vite] Remove dependency on benchmark gem to fix warnings

### DIFF
--- a/template/test/vite_helper.rb
+++ b/template/test/vite_helper.rb
@@ -3,6 +3,5 @@
 return if ViteRuby.config.auto_build
 
 # Compile assets once at the start of testing
-require "benchmark"
-seconds = Benchmark.realtime { ViteRuby.commands.build }
+seconds = ActiveSupport::Benchmark.realtime { ViteRuby.commands.build }
 puts format("Built Vite assets (%.1fms)", seconds * 1_000)


### PR DESCRIPTION
The `vite_helper.rb` file generated by nextgen contained a reference to the `benchmark` gem. This leads to warnings on Ruby 3.4.7 due to the fact that benchmark will no longer be bundled with Ruby in the future.

Fix this warning by using `ActiveSupport::Benchmark` instead.