### PR TITLE
Fix missing `ruby` declaration in generated Gemfile

### DIFF
--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -41,7 +41,9 @@ if File.exist?("test/application_system_test_case.rb")
 end
 
 missing_ruby_decl = !File.read("Gemfile").match?(/^ruby /)
-if missing_ruby_decl && File.exist?(".ruby-version") && File.read(".ruby-version").match?(/\A\d+\.\d+.\d+.\s*\z/m)
+if missing_ruby_decl &&
+    File.exist?(".ruby-version") &&
+    File.read(".ruby-version").match?(/\A(ruby-)?\d+\.\d+.\d+.\s*\z/m)
   say_git "Add ruby declaration to Gemfile"
   ruby_decl = if bundler_ruby_file_supported?
                 'ruby file: ".ruby-version"'


### PR DESCRIPTION
Before, `rails new` generated a `.ruby-version` file like this:

    3.4.7

Now, it generates:

    ruby-3.4.7

Update our regex so that we detect this as an acceptable ruby version, such that nextgen adds `ruby file: ".ruby-version"` as it did before.