### PR TITLE
Prevent reserved word app names

### DIFF
--- a/lib/nextgen/commands/create.rb
+++ b/lib/nextgen/commands/create.rb
@@ -118,7 +118,7 @@ module Nextgen
       say <<~APP_NAME
         Your Rails app name: "#{cyan(app_name)}", is a reserved word. Please rerun the initial command with an unreserved word instead.
       APP_NAME
-      exit
+      exit(false)
     end
 
     def continue_if(question)


### PR DESCRIPTION
Hello there, I was testing this gem and decided to create an application named test, I then proceeded to select all my options and at the very end the App creation failed because, well, test is a reserved word of course. I figured I would take some inspiration from what Rails new does here https://github.com/rails/rails/blob/d274ddaf7cedc9e5029c112450cb0048dc1ae2a1/railties/lib/rails/generators/app_name.rb#L6 
and exit early with a message if the user is indeed using a reserved word for their app.

```
> bundle exec exe/nextgen create test
Your Rails app name: "Test", is a reserved word. Please rerun the initial command with an unreserved word instead.
```