### PR TITLE
Ensure system test set up works on Rails edge

### DIFF
--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -32,7 +32,7 @@ append_to_file "Rakefile", <<~RUBY
   end
 RUBY
 
-if File.exist?("test/application_system_test_case.rb")
+if File.read("Gemfile").match?(/^\s*gem ['"]capybara['"]/)
   say_git "Configure system tests"
   copy_test_support_file "capybara.rb.tt"
   copy_file "test/application_system_test_case.rb", force: true


### PR DESCRIPTION
In Rails edge (8.2/9.0), the `application_system_test_case.rb` file is not generated by default. Instead, Rails wants you to explicitly opt into system tests by running `rails generate system_test`.

Nextgen assumed that this file was always present, and would crash as a result when generating an app with Rails edge. This fix changes how nextgen detects system test support by looking for the capybara gem instead.