### PR TITLE
Fix `rails test:system` failure on newly generated app

### DIFF
--- a/lib/nextgen/generators/base.rb
+++ b/lib/nextgen/generators/base.rb
@@ -36,6 +36,7 @@ if File.read("Gemfile").match?(/^\s*gem ['"]capybara['"]/)
   say_git "Configure system tests"
   copy_test_support_file "capybara.rb.tt"
   copy_file "test/application_system_test_case.rb", force: true
+  empty_directory_with_keep_file "test/system"
   gsub_file "Gemfile", /gem "capybara"$/, '\0, require: false'
   gsub_file "Gemfile", /gem "selenium-webdriver"$/, '\0, require: false'
 end

--- a/lib/nextgen/generators/rspec_system_testing.rb
+++ b/lib/nextgen/generators/rspec_system_testing.rb
@@ -3,6 +3,7 @@
 install_gems "capybara", "selenium-webdriver", group: :test, require: false
 copy_test_support_file "capybara.rb.tt"
 copy_test_support_file "system.rb"
+empty_directory_with_keep_file "spec/system"
 
 copy_file "lib/templates/rspec/system/system_spec.rb"
 prevent_autoload_lib "templates"


### PR DESCRIPTION
After generating app with system testing enabled, running `rails test:system` (locally, or via the generated CI step) would fail with an error like this:

```
'Kernel.require': cannot load such file -- /Users/mbrictson/Code/nextgen/foo/test/system (LoadError)
```

Fix by ensuring the `test/system` directory exists.